### PR TITLE
Use UTC timestamps everywhere/improve sitemap generation (fixes #7657)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ caches/*
 akara.ini
 akara.conf
 akara.confc
+ENV/*

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-The DPLA Ingestion
+The DPLA Ingestion System
 -------------------
 
 Build Status
@@ -45,6 +45,7 @@ Configure an akara.ini file appropriately for your environment;
 
     [Sitemap]
     SitemapURI=<Sitemap URI>
+    SitemapPath=<Path to local directory for sitemap files>
     
     [Alert]
     To=<Comma-separated email addresses to receive alert email>

--- a/lib/akamod/enrich.py
+++ b/lib/akamod/enrich.py
@@ -1,4 +1,3 @@
-import datetime
 import re
 from akara import logger
 from akara import request
@@ -6,6 +5,7 @@ from amara.lib.iri import is_absolute
 from akara.services import simple_service
 from akara.util import copy_headers_to_dict
 from amara.thirdparty import json, httplib2
+from dplaingestion.utilities import iso_utc_with_tz
 
 H = httplib2.Http()
 H.force_exception_as_status_code = True
@@ -73,7 +73,8 @@ def enrich(body, ctype):
             record["originalRecord"] = record.copy()         
             record["ingestType"] = "item"
 
-        record["ingestDate"] = datetime.datetime.now().isoformat()
+        # Explicitly populate ingestDate as UTC
+        record["ingestDate"] = iso_utc_with_tz()
 
         error, enriched_record_text = pipe(record, ctype, enrichments,
                                            wsgi_header)

--- a/lib/couch.py
+++ b/lib/couch.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 from datetime import datetime
 from dplaingestion.selector import setprop
 from dplaingestion.dict_differ import DictDiffer
+from dplaingestion.utilities import iso_utc_with_tz
 
 class Couch(object):
     """A class to hold the couchdb-python functionality used during ingestion.
@@ -366,7 +367,7 @@ class Couch(object):
            the backup database, returning the backup database name.
         """
         backup_db_name = "%s_%s" % (provider,
-                                    datetime.now().strftime("%Y%m%d%H%M%S"))
+                                    datetime.utcnow().strftime("%Y%m%d%H%M%S"))
         backup_db = self.server.create(backup_db_name)
 
         msg = "Backing up %s to database %s" % (provider, backup_db_name)
@@ -411,7 +412,7 @@ class Couch(object):
             "provider": provider,
             "type": "ingestion",
             "ingestionSequence": None,
-            "ingestDate": datetime.now().isoformat(),
+            "ingestDate": iso_utc_with_tz(),
             "countAdded": 0,
             "countChanged": 0,
             "countDeleted": 0,
@@ -519,7 +520,7 @@ class Couch(object):
         ingestion_doc = {
             "provider": provider,
             "type": "ingestion",
-            "ingestDate": datetime.now().isoformat(),
+            "ingestDate": iso_utc_with_tz(),
             "countAdded": 0,
             "countChanged": 0,
             "countDeleted": 0
@@ -852,7 +853,7 @@ class Couch(object):
         bulk_download_doc.update({
             "file_path": file_path,
             "file_size": file_size,
-            "last_updated": datetime.now().isoformat()
+            "last_updated": iso_utc_with_tz()
             })
 
         return self.bulk_download_db.save(bulk_download_doc)[0]
@@ -880,5 +881,5 @@ class Couch(object):
                  self._generic_exception_error_msg(e, what)
 
     def _ts_for_err(self):
-        return "[%s]" % datetime.now().isoformat()
+        return "[%s]" % iso_utc_with_tz()
 

--- a/lib/mapv3.py
+++ b/lib/mapv3.py
@@ -22,10 +22,7 @@ MAPV3_SCHEMAS = {
             },
             "description": {"$ref": "#/definitions/arrayOrString"},
             "ingestionSequence": {"type": "number"},
-            # do not check ingestDate as the 'date-time' json-schema
-            # format, since it requires RFC 3339 conformance and not
-            # ISO 8601 conformance
-            "ingestDate": {"type": "string"},
+            "ingestDate": {"type": "string", "format": "date-time"},
             "ingestType": {"type": "string", "enum": ["collection"]},
             "id": {"type": "string"},
             "title": {"$ref": "#/definitions/arrayOrString"}
@@ -73,10 +70,7 @@ MAPV3_SCHEMAS = {
             },
             "id": {"type": "string"},
             "ingestionSequence": {"type": ["number", "null"]},
-            # do not check ingestDate as the 'date-time' json-schema
-            # format, since it requires RFC 3339 conformance and not
-            # ISO 8601 conformance
-            "ingestDate": {"type": "string"},
+            "ingestDate": {"type": "string", "format": "date-time"},
             "ingestType": {"type": "string", "enum": ["item"]},
             "isShownAt": {"type": "string", "format": "uri"},
             "object": {"type": "string", "format": "uri"},
@@ -118,10 +112,7 @@ MAPV3_SCHEMAS = {
                     },
                     "description": {"$ref": "#/definitions/arrayOrString"},
                     "ingestionSequence": {"type": "number"},
-                    # do not check ingestDate as the 'date-time' json-schema
-                    # format, since it requires RFC 3339 conformance and not
-                    # ISO 8601 conformance
-                    "ingestDate": {"type": "string"},
+                    "ingestDate": {"type": "string", "format": "date-time"},
                     "ingestType": {"type": "string", "enum": ["collection"]},
                     "id": {"type": "string"},
                     "title": {"$ref": "#/definitions/arrayOrString"}

--- a/lib/utilities.py
+++ b/lib/utilities.py
@@ -5,6 +5,7 @@ import time
 import tarfile
 import re
 from functools import wraps
+from datetime import datetime
 
 def iterify(iterable):
     """Treat iterating over a single item or an iterator seamlessly"""
@@ -122,3 +123,7 @@ def remove_all_brackets_and_strip(d):
 
 def strip_unclosed_brackets(s):
     return re.sub(r'\[(?![^\]]*?\])', '', s)
+
+def iso_utc_with_tz(dt=datetime.utcnow()):
+    """Given a UTC datetime, return an ISO 8601-conformant string w/ timezone"""
+    return dt.isoformat() + "Z"

--- a/scripts/check_ingestion_counts.py
+++ b/scripts/check_ingestion_counts.py
@@ -18,6 +18,7 @@ import smtplib
 from email.mime.text import MIMEText
 from dateutil import parser as dateparser
 import ConfigParser
+from dplaingestion.utilities import iso_utc_with_tz
 
 
 def define_arguments():
@@ -41,7 +42,7 @@ def main(argv):
     # Update ingestion document
     kwargs = {
         "check_counts_process/status": "running",
-        "check_counts_process/start_time": datetime.now().isoformat()
+        "check_counts_process/start_time": iso_utc_with_tz()
     }
     try:
         couch.update_ingestion_doc(ingestion_doc, **kwargs)
@@ -93,7 +94,7 @@ def main(argv):
     kwargs = {
         "check_counts_process/status": status,
         "check_counts_process/error": error_msg,
-        "check_counts_process/end_time": datetime.now().isoformat()
+        "check_counts_process/end_time": iso_utc_with_tz()
     }
     try:
         couch.update_ingestion_doc(ingestion_doc, **kwargs)

--- a/scripts/create_sitemap.py
+++ b/scripts/create_sitemap.py
@@ -2,22 +2,28 @@ import os
 import time
 import shutil
 import tarfile
-import datetime
+from datetime import date, datetime
+from dateutil.parser import parse as dateutil_parse
 import ConfigParser
 from dplaingestion.couch import Couch
+from dplaingestion.utilities import iso_utc_with_tz
 from export_database import set_global_variables
 from export_database import get_rackspace_connection
 from export_database import get_rackspace_container
 from export_database import file_is_in_container
 from export_database import url_join
 
+# TODO: Make a generalized config loader for all the scripts.
+config_file = "akara.ini"
+CONFIG = ConfigParser.ConfigParser()
+CONFIG.readfp(open(config_file))
 set_global_variables("SitemapContainer")
 CONTAINER = get_rackspace_container()
 
 def send_sitemap_to_rackspace(sitemap_files_path):
     global CONTAINER
 
-    print "Loading files from %s to Rackspace CDN." % sitemap_path
+    print "Loading files from %s to Rackspace CDN." % sitemap_files_path
     for item in os.listdir(sitemap_files_path):
         f = CONTAINER.create_object(item)
         f.load_from_filename(os.path.join(sitemap_files_path, item))
@@ -29,7 +35,6 @@ def send_sitemap_to_rackspace(sitemap_files_path):
             print "Couldn't upload file to Rackspace CDN."
 
 def create_sitemap_files(path, urls, count):
-    lastmod = datetime.date.today().strftime("%Y-%m-%d")
     fpath = os.path.join(path, "all_item_urls_%s.xml" % count)
     with open(fpath, "w") as f:
         line = '<?xml version="1.0" encoding="UTF-8"?>\n' + \
@@ -38,19 +43,14 @@ def create_sitemap_files(path, urls, count):
         for url in urls:
             line = "\t<url>\n" + \
                    "\t\t<loc>%s</loc>\n\t\t<lastmod>%s</lastmod>\n" % \
-                   (url, lastmod)
+                   (url["loc"], url["lastmod"])
             line += "\t\t<changefreq>monthly</changefreq>\n\t</url>\n"
             f.write(line)
         f.write("</urlset>")
 
 def create_sitemap_index(path):
-    config_file = "akara.ini"
-    config = ConfigParser.ConfigParser()
-    config.readfp(open(config_file))
-    site_map_uri = config.get("Sitemap", "SitemapURI")
-
-    lastmod = datetime.date.today().strftime("%Y-%m-%d")
-    lastmod = datetime.date.today().strftime("%Y-%m-%d")
+    global CONFIG
+    site_map_uri = CONFIG.get("Sitemap", "SitemapURI")
     fpath = os.path.join(path, "all_item_urls.xml")
     with open(fpath, "w") as f:
         line = '<?xml version="1.0" encoding="UTF-8"?>\n' + \
@@ -63,17 +63,16 @@ def create_sitemap_index(path):
                 continue
             # sitemaps.dp.la is a CNAME pointing to the CDN host
             file_uri = url_join(site_map_uri, item)
-            lastmod = time.strftime("%Y-%m-%dT%H:%M:%S%z",
-                                    time.gmtime(os.path.getmtime(
-                                        os.path.join(path, item)
-                                        )))
+            lastmod_dt = datetime.utcfromtimestamp(os.path.getmtime(
+                                                os.path.join(path, item)
+                                                ))
             line = "\t<sitemap>\n" + \
                    "\t\t<loc>%s</loc>\n\t\t<lastmod>%s</lastmod>\n" % \
-                   (file_uri, lastmod) + "\t</sitemap>\n"
+                   (file_uri, iso_utc_with_tz(lastmod_dt)) + "\t</sitemap>\n"
             f.write(line)
         f.write("</sitemapindex>")
 
-sitemap_path = "/home/dpla/data/sitemap"
+sitemap_path = CONFIG.get("Sitemap", "SitemapPath")
 
 # Compress previous directory
 for item in os.listdir(sitemap_path):
@@ -84,7 +83,7 @@ for item in os.listdir(sitemap_path):
         shutil.rmtree(item_path)
 
 # Create new directory
-new_dir = os.path.join(sitemap_path, datetime.date.today().strftime("%Y%m%d"))
+new_dir = os.path.join(sitemap_path, date.today().strftime("%Y%m%d"))
 os.mkdir(new_dir)
 
 # Fetch all item URLs
@@ -94,7 +93,13 @@ limit = 50000
 count = 1
 for doc in c._query_all_docs(c.dpla_db):
     if doc.get("ingestType") == "item":
-        urls.append("http://dp.la/item/" + doc["id"])
+        # Handle older ingestDates, which do not have timezone info.
+        lm_dt = dateutil_parse(doc["ingestDate"])
+        if lm_dt.utcoffset():
+            lm = lm_dt.isoformat()
+        else:
+            lm = lm_dt.isoformat() + "Z"
+        urls.append({"loc": "http://dp.la/item/" + doc["id"], "lastmod": lm})
     if len(urls) == limit:
         create_sitemap_files(new_dir, urls, count)
         count += 1

--- a/scripts/dashboard_cleanup.py
+++ b/scripts/dashboard_cleanup.py
@@ -10,10 +10,10 @@ import os
 import sys
 import argparse
 from akara import logger
-from datetime import datetime
 from amara.thirdparty import json
 from dplaingestion.couch import Couch
 from dplaingestion.selector import getprop
+from dplaingestion.utilities import iso_utc_with_tz
 
 def define_arguments():
     """Defines command line arguments for the current script"""
@@ -36,7 +36,7 @@ def main(argv):
     # Update ingestion document
     kwargs = {
         "dashboard_cleanup_process/status": "running",
-        "dashboard_cleanup_process/start_time": datetime.now().isoformat(),
+        "dashboard_cleanup_process/start_time": iso_utc_with_tz(),
         "dashboard_cleanup_process/end_time": None,
         "dashboard_cleanup_process/error": None
     }
@@ -59,7 +59,7 @@ def main(argv):
     kwargs = {
         "dashboard_cleanup_process/status": status,
         "dashboard_cleanup_process/error": error_msg,
-        "dashboard_cleanup_process/end_time": datetime.now().isoformat()
+        "dashboard_cleanup_process/end_time": iso_utc_with_tz()
     }
     try:
         couch.update_ingestion_doc(ingestion_doc, **kwargs)

--- a/scripts/enrich_records.py
+++ b/scripts/enrich_records.py
@@ -22,7 +22,7 @@ from datetime import datetime
 from amara.thirdparty import json
 from dplaingestion.couch import Couch
 from dplaingestion.selector import getprop
-from dplaingestion.utilities import make_tarfile
+from dplaingestion.utilities import make_tarfile, iso_utc_with_tz
 
 config = ConfigParser.ConfigParser()
 config.readfp(open('akara.ini'))
@@ -172,7 +172,7 @@ def main(argv):
     kwargs = {
         "enrich_process/status": status,
         "enrich_process/data_dir": enrich_dir,
-        "enrich_process/start_time": datetime.now().isoformat(),
+        "enrich_process/start_time": iso_utc_with_tz(),
         "enrich_process/end_time": None,
         "enrich_process/error": None,
         "enrich_process/total_items": None,
@@ -258,7 +258,7 @@ def main(argv):
         couch_kwargs = {
             "enrich_process/status": status,
             "enrich_process/error": dashboard_errors,
-            "enrich_process/end_time": datetime.now().isoformat(),
+            "enrich_process/end_time": iso_utc_with_tz(),
             "enrich_process/total_items": stats['enriched_items'],
             "enrich_process/total_collections": stats['enriched_colls'],
             "enrich_process/missing_id": stats['missing_id'],

--- a/scripts/fetch_records.py
+++ b/scripts/fetch_records.py
@@ -19,7 +19,7 @@ from datetime import datetime
 from amara.thirdparty import json
 from dplaingestion.couch import Couch
 from dplaingestion.selector import getprop
-from dplaingestion.utilities import iterify
+from dplaingestion.utilities import iterify, iso_utc_with_tz
 from dplaingestion.create_fetcher import create_fetcher
 
 
@@ -167,7 +167,7 @@ def main(argv):
     kwargs = {
         "fetch_process/status": "running",
         "fetch_process/data_dir": fetch_dir,
-        "fetch_process/start_time": datetime.now().isoformat(),
+        "fetch_process/start_time": iso_utc_with_tz(),
         "fetch_process/end_time": None,
         "fetch_process/error": None,
         "fetch_process/total_items": None,
@@ -268,7 +268,7 @@ def main(argv):
     kwargs = {
         "fetch_process/status": status,
         "fetch_process/error": error_msg,
-        "fetch_process/end_time": datetime.now().isoformat(),
+        "fetch_process/end_time": iso_utc_with_tz(),
         "fetch_process/total_items": stats["total_items"],
         "fetch_process/total_collections": stats["total_collections"]
     }

--- a/scripts/poll_storage.py
+++ b/scripts/poll_storage.py
@@ -31,6 +31,7 @@ import check_ingestion_counts
 from datetime import datetime
 from dplaingestion.couch import Couch
 from amara.thirdparty import json, httplib2
+from dplaingestion.utilities import iso_utc_with_tz
 
 ENRICH = "/enrich_storage"
 H = httplib2.Http()
@@ -102,7 +103,7 @@ def main(argv):
     # Update ingestion document
     kwargs = {
         "poll_storage_process/status": "running",
-        "poll_storage_process/start_time": datetime.now().isoformat(),
+        "poll_storage_process/start_time": iso_utc_with_tz(),
         "poll_storage_process/end_time": None,
     }
     try:
@@ -118,7 +119,7 @@ def main(argv):
         # Fatal error, do not continue with save process
         kwargs = { 
             "poll_storage_process/status": "error",
-            "poll_storage_process/end_time": datetime.now().isoformat(),
+            "poll_storage_process/end_time": iso_utc_with_tz(),
             "poll_storage_process/error": "Error backing up DPLA records"
         }   
         couch.update_ingestion_doc(ingestion_doc, **kwargs)
@@ -199,7 +200,7 @@ def main(argv):
     # Update ingestion document
     kwargs = {
         "poll_storage_process/status": "complete",
-        "poll_storage_process/end_time": datetime.now().isoformat(),
+        "poll_storage_process/end_time": iso_utc_with_tz(),
         "poll_storage_process/total_items": enriched_items,
         "poll_storage_process/total_collections":  enriched_colls,
         "poll_storage_process/missing_id": missing_id,

--- a/scripts/remove_deleted_records.py
+++ b/scripts/remove_deleted_records.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from amara.thirdparty import json
 from dplaingestion.couch import Couch
 from dplaingestion.selector import getprop
+from dplaingestion.utilities import iso_utc_with_tz
 
 def define_arguments():
     """Defines command line arguments for the current script"""
@@ -35,7 +36,7 @@ def main(argv):
     # Update ingestion document
     kwargs = {
         "delete_process/status": "running",
-        "delete_process/start_time": datetime.now().isoformat()
+        "delete_process/start_time": iso_utc_with_tz()
     }
     try:
         couch.update_ingestion_doc(ingestion_doc, **kwargs)
@@ -59,7 +60,7 @@ def main(argv):
     kwargs = {
         "delete_process/status": status,
         "delete_process/error": error_msg,
-        "delete_process/end_time": datetime.now().isoformat()
+        "delete_process/end_time": iso_utc_with_tz()
     }
     try:
         couch.update_ingestion_doc(ingestion_doc, **kwargs)

--- a/scripts/save_records.py
+++ b/scripts/save_records.py
@@ -15,7 +15,8 @@ from datetime import datetime
 from amara.thirdparty import json
 from dplaingestion.couch import Couch
 from dplaingestion.selector import getprop
-from dplaingestion.utilities import make_tarfile
+from dplaingestion.utilities import make_tarfile, iso_utc_with_tz
+
 
 def define_arguments():
     """Defines command line arguments for the current script"""
@@ -43,7 +44,7 @@ def main(argv):
     # Update ingestion document
     kwargs = {
         "save_process/status": "running",
-        "save_process/start_time": datetime.now().isoformat(),
+        "save_process/start_time": iso_utc_with_tz(),
         "save_process/end_time": None,
         "save_process/error": None,
         "save_process/total_saved": None
@@ -62,7 +63,7 @@ def main(argv):
             # Fatal error, do not continue with save process
             kwargs = {
                 "save_process/status": "error",
-                "save_process/end_time": datetime.now().isoformat(),
+                "save_process/end_time": iso_utc_with_tz(),
                 "save_process/error": "Error backing up DPLA records"
             }
             couch.update_ingestion_doc(ingestion_doc, **kwargs)
@@ -131,7 +132,7 @@ def main(argv):
     kwargs = {
         "save_process/status": status,
         "save_process/error": error_msg,
-        "save_process/end_time": datetime.now().isoformat(),
+        "save_process/end_time": iso_utc_with_tz(),
         "save_process/total_items": total_items,
         "save_process/total_collections": total_collections
     }

--- a/scripts/upload_bulk_data.py
+++ b/scripts/upload_bulk_data.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from amara.thirdparty import json
 from dplaingestion.couch import Couch
 from dplaingestion.selector import getprop
+from dplaingestion.utilities import iso_utc_with_tz
 
 def define_arguments():
     """Defines command line arguments for the current script"""
@@ -38,8 +39,7 @@ def main(argv):
     # Update ingestion document
     kwargs = {
         "upload_bulk_data_process/status": "running",
-        "upload_bulk_data_process/start_time": datetime.now()\
-                                                                .isoformat(),
+        "upload_bulk_data_process/start_time": iso_utc_with_tz(),
         "upload_bulk_data_process/end_time": None,
         "upload_bulk_data_process/error": None,
     }
@@ -66,8 +66,7 @@ def main(argv):
     kwargs = {
         "upload_bulk_data_process/status": status,
         "upload_bulk_data_process/error": error_msg,
-        "upload_bulk_data_process/end_time": datetime.now()\
-                                                              .isoformat()
+        "upload_bulk_data_process/end_time": iso_utc_with_tz()
     }
     try:
         couch.update_ingestion_doc(ingestion_doc, **kwargs)

--- a/test/test_iso_utc_with_tz.py
+++ b/test/test_iso_utc_with_tz.py
@@ -1,0 +1,12 @@
+import sys
+from datetime import datetime
+from dplaingestion.utilities import iso_utc_with_tz
+
+def test_iso_utc_with_tz():
+    """iso_utc_with_tz() should yield a UTC datetime as a string with timezone symbol Z"""
+    utc_now = datetime.utcnow()
+    utc_now_iso_string_with_tz = utc_now.isoformat() + "Z"
+    assert utc_now_iso_string_with_tz == iso_utc_with_tz(utc_now)
+
+if __name__ == "__main__":
+    raise SystemExit("Use nosetest")

--- a/test/test_validate_mapv3.py
+++ b/test/test_validate_mapv3.py
@@ -86,7 +86,7 @@ def test_validate_mapv3_valid_item():
             "type": "image"
         },
         "object": "http://texashistory.unt.edu/ark:/67531/metapth245858/thumbnail/",
-        "ingestDate": "2014-02-26T07:47:43.391637",
+        "ingestDate": "2014-02-26T07:47:43.391637Z",
         "originalRecord": {
             "provider": {
                 "name": "The Portal to Texas History",
@@ -127,7 +127,7 @@ def test_validate_mapv3_valid_coll():
         "@id": "http://dp.la/api/collections/6814902bd6e5f107185a764123c18dda",
         "ingestType": "collection",
         "ingestionSequence": 7,
-        "ingestDate": "2014-04-29T17:58:39.828429",
+        "ingestDate": "2014-04-29T17:58:39.828429Z",
         "title": "Gillespie County Historical Society",
         "description": "",
         "_id": "texas--partner:GCHS"
@@ -195,7 +195,7 @@ def test_validate_mapv3_invalid_item():
             },
         },
         "object": "http://texashistory.unt.edu/ark:/67531/metapth245858/thumbnail/",
-        "ingestDate": "2014-02-26T07:47:43.391637",
+        "ingestDate": "2014-02-26T07:47:43.391637Z",
         "ingestionSequence": 5,
         "isShownAt": "http://texashistory.unt.edu/ark:/67531/metapth245858/"
     }


### PR DESCRIPTION
- Sitemaps require `<lastmod>` dates to be in W3C Datetime format
- Use `ingestDate` from items to populate `<lastmod>`
- Move configuration loading logic outside functions
- Add configuration option for local sitemap path -- required change to `akara.ini`
