### PR TITLE
Add SCDLCharlestonMapper for object mapping (#7651)

### DIFF
--- a/lib/create_mapper.py
+++ b/lib/create_mapper.py
@@ -28,6 +28,10 @@ def create_mapper(mapper_type, data):
         from dplaingestion.mappers.scdl_mapper import SCDLMapper
         return SCDLMapper(data)
 
+    def _create_charleston_mapper(data):
+        from dplaingestion.mappers.charleston_mapper import SCDLCharlestonMapper
+        return SCDLCharlestonMapper(data)
+
     def _create_edan_mapper(data):
         from dplaingestion.mappers.edan_mapper import EDANMapper
         return EDANMapper(data)
@@ -83,6 +87,7 @@ def create_mapper(mapper_type, data):
         'mdl':          lambda d: _create_mdl_mapper(d),
         'gpo':          lambda d: _create_gpo_mapper(d),
         'scdl':         lambda d: _create_scdl_mapper(d),
+        'charleston':   lambda d: _create_charleston_mapper(d),
         'edan':         lambda d: _create_edan_mapper(d),
         'nara':         lambda d: _create_nara_mapper(d),
         'nypl':         lambda d: _create_nypl_mapper(d),

--- a/lib/mappers/charleston_mapper.py
+++ b/lib/mappers/charleston_mapper.py
@@ -1,0 +1,21 @@
+"""
+SCDL Charleston Mapper
+"""
+
+
+from dplaingestion.mappers.scdl_mapper import SCDLMapper
+
+
+class SCDLCharlestonMapper(SCDLMapper):
+
+    def map_object(self):
+        """Map .object, based on the record header identifier"""
+        # _id includes the value of what was //header/identifier in the
+        # OAI feed, and reliably gives the identifier that's needed to
+        # construct the thumbnail url.
+        id_prop = self.provider_data['_id']
+        identifier = id_prop.split('/')[-1]
+        obj_url = 'http://fedora.library.cofc.edu:8080' \
+                  '/fedora/objects/%s/datastreams' \
+                  '/THUMB1/content' % identifier
+        self.mapped_data.update({'object': obj_url})

--- a/profiles/scdl-charleston.pjs
+++ b/profiles/scdl-charleston.pjs
@@ -2,8 +2,8 @@
     "name": "scdl-charleston",
     "type": "oai_verbs",
     "metadata_prefix": "qdc",
-    "endpoint_url": "http://lowcountrydigital.library.cofc.edu/cgi-bin/oai.exe",
-    "sets": [],
+    "endpoint_url": "http://lcdl.library.cofc.edu/lcdl/oai",
+    "sets": "NotSupported",
     "contributor": {
         "@id": "http://dp.la/api/contributor/scdl-charleston",
         "name": "South Carolina Digital Library"
@@ -14,7 +14,7 @@
     ],
     "enrichments_item": [
         "/select-id", 
-        "/dpla_mapper?mapper_type=scdl",
+        "/dpla_mapper?mapper_type=charleston",
         "/set_context",
         "/shred?prop=sourceResource%2Fcontributor%2CsourceResource%2Fcreator%2CsourceResource%2Fdate",
         "/shred?prop=sourceResource%2Flanguage%2CsourceResource%2Fpublisher%2CsourceResource%2Frelation",
@@ -36,7 +36,6 @@
         "/shred?prop=sourceResource%2Fformat",
         "/enrich-format",
         "/scdl_format_to_type",
-        "/contentdm_identify_object",
         "/enrich_location",
         "/scdl_enrich_location",
         "/geocode",

--- a/test/test_charleston_mapper.py
+++ b/test/test_charleston_mapper.py
@@ -1,0 +1,17 @@
+from dplaingestion.mappers.charleston_mapper import SCDLCharlestonMapper
+
+
+def test_map_object():
+    """SCDLCharlestonMapper derives object from ID"""
+    provider_data = {
+        '_id': 'scdl-charleston--http://lcdl.library.cofc.edu'
+               '/lcdl/catalog/lcdl:4633'
+    }
+    cm = SCDLCharlestonMapper(provider_data)
+    cm.map_object()
+    expected = {
+        'sourceResource': {},
+        'object': 'http://fedora.library.cofc.edu:8080'
+                  '/fedora/objects/lcdl:4633/datastreams/THUMB1/content'
+    }
+    assert cm.mapped_data == expected


### PR DESCRIPTION
This should resolve https://issues.dp.la/issues/7651

College of Charleston (one of three South Carolina Digital Library providers) unexpectedly moved to a new repository system and we had to change the OAI endpoint URL, the 'set' specification, and the mapping of the 'object' property as a result.

CharlestonMapper extends SCDLMapper in order to perform special mapping of the 'object' property that is different than that of the other SCDL providers.  The included test describes the desired behavior. 
