### PR TITLE
Enable/disable building of QA views (refs #7545)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Configure an akara.ini file appropriately for your environment;
     Url=<URL to CouchDB instance, including trailing forward-slash>
     Username=<CouchDB username>
     Password=<CouchDB password>
+    SyncQAViews=<True or False; consider False on production>
 
     [Geonames]
     Username=<Geonames username>

--- a/lib/couch.py
+++ b/lib/couch.py
@@ -83,18 +83,19 @@ class Couch(object):
         """Return the result of the given view in the "dpla" database"""
         return self.dpla_db.view(viewname, None, **options)
 
-    def sync_views(self, db_name):
+    def sync_views(self, db_name, sync_qa_views=True):
         """Fetches design documents from the views_directory, saves/updates
            them in the appropriate database, then build the views. 
         """
         build_views_from_file = ["dpla_db_all_provider_docs.js",
-                                 "dpla_db_qa_reports.js",
                                  "dashboard_db_all_provider_docs.js",
                                  "dashboard_db_all_ingestion_docs.js",
                                  "dpla_db_export_database.js",
                                  "bulk_download_db_all_contributor_docs.js"]
         if db_name == "dpla":
             db = self.dpla_db
+            if sync_qa_views:
+                build_views_from_file.append("dpla_db_qa_reports.js")
         elif db_name == "dashboard":
             db = self.dashboard_db
         elif db_name == "bulk_download":

--- a/scripts/sync_couch_views.py
+++ b/scripts/sync_couch_views.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 """
-Script to add/update then build the views of a database.
+Script to add/update then build the views of a database. By default,
+it will sync QA views required by the Content QA application. To disable
+syncing of QA views, set CouchDb.SyncQAViews to "False" in akara.ini.
 
 Usage:
     $ python scripts/sync_couch_views.py <database_name>
@@ -10,7 +12,12 @@ Usage:
 import sys
 import time
 import argparse
+import ConfigParser
 from dplaingestion.couch import Couch
+
+# ConfigParser.ConfigParser().getboolean() expects a string
+config = ConfigParser.ConfigParser({"SyncQAViews": "True"})
+config.readfp(open('akara.ini'))
 
 def define_arguments():
     """Defines command line arguments for the current script"""
@@ -25,11 +32,11 @@ def define_arguments():
 def main(argv):
     parser = define_arguments()
     args = parser.parse_args(argv[1:])
-
+    sync_qa_views = config.getboolean('CouchDb', 'SyncQAViews')
     couch = Couch()
     database_names = ["dpla", "dashboard", "bulk_download"]
     if args.database_name in database_names:
-        couch.sync_views(args.database_name)
+        couch.sync_views(args.database_name, sync_qa_views)
     else:
         print >> sys.stderr, "The database_name parameter should be " + \
                              "either %s" % " or ".join(database_names)


### PR DESCRIPTION
Adds a new configuration option, `CouchDb.SyncQAViews`, read by the sync_couch_views.py script. The `Couch().sync_views()` method now also accepts a `sync_qa_views` argument.
