### PR TITLE
Add module to strip HTML tags (#7636)

### DIFF
--- a/akara.conf.template
+++ b/akara.conf.template
@@ -196,6 +196,7 @@ MODULES = [
     "dplaingestion.akamod.validate_mapv3",
     "dplaingestion.akamod.dpla_mapper",
     "dplaingestion.akamod.set_context",
+    "dplaingestion.akamod.strip_html"
     ]
 
 ### Section 3: Other module configuration goes here

--- a/lib/akamod/strip_html.py
+++ b/lib/akamod/strip_html.py
@@ -1,0 +1,46 @@
+"""
+Pipeline module to recursively strip HTML tags from all strings found in the
+posted object
+"""
+
+import json
+from markupsafe import Markup
+from akara import response
+from akara.services import simple_service
+
+
+@simple_service('POST',
+                'http://purl.org/la/dp/strip_html',
+                'strip_html',
+                'application/json')
+def strip_html(body, ctype_ignored):
+    """Strip HTML tags and whitespace from strings within the given object
+
+    Remove HTML tags and convert HTML entities to UTF-8 characters.
+    Compacts consecutive whitespace to single space characters, and strips
+    whitespace from ends of strings.
+    """
+    try:
+        d = json.loads(body)
+        return json.dumps(_strip_r(d))
+    except Exception as e:
+        response.code = 500
+        response.add_header('Content-Type', 'text/plain')
+        if type(e) == ValueError:
+            return 'Unable to parse request body as JSON'
+        else:
+            return e.message
+
+def _strip_r(thing):
+    """Recursively strip HTML tags and whitespace from strings"""
+    if isinstance(thing, basestring):
+        return Markup(thing).striptags()
+    if type(thing) == dict:
+        items = thing.iteritems()
+    elif type(thing) == list:
+        items = enumerate(thing)
+    else:
+        return thing
+    for key, value in items:
+        thing[key] = _strip_r(value)
+    return thing

--- a/profiles/smithsonian.pjs
+++ b/profiles/smithsonian.pjs
@@ -13,6 +13,7 @@
     "enrichments_item": [
         "/edan_select_id",
         "/dpla_mapper?mapper_type=edan",
+        "/strip_html",
         "/set_context",
         "/shred?prop=sourceResource%2Fformat",
         "/shred?prop=sourceResource%2Fsubject&delim=%5C",

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ geopy
 python-cloudfiles
 ordereddict
 jsonschema==2.3.0
+MarkupSafe==0.23

--- a/test/server_support.py
+++ b/test/server_support.py
@@ -190,7 +190,8 @@ MODULES = [
     "dplaingestion.akamod.mdl_state_located_in",
     "dplaingestion.akamod.scdl_format_to_type",
     "dplaingestion.marc_code_to_relator",
-    "dplaingestion.akamod.validate_mapv3"
+    "dplaingestion.akamod.validate_mapv3",
+    "dplaingestion.akamod.strip_html"
     ]
 
 class geocode: 

--- a/test/test_strip_html.py
+++ b/test/test_strip_html.py
@@ -1,0 +1,28 @@
+import json
+from server_support import server, H
+from dict_differ import assert_same_jsons
+
+
+def test_strip_html():
+    """'strip_html' strips HTML tags and entities recursively"""
+    request_data = {
+        'a': {
+            'b': [' <i>string</i> <b>one</b> \n \t', 'string &lt; two  ']
+        },
+        'c': '  \n <p>string three</p>',
+        'd': {},
+        'e': 1
+    }
+    expected_result = {
+        'a': {
+            'b': [u'string one', u'string < two']
+        },
+        'c': u'string three',
+        'd': {},  # unaltered
+        'e': 1    # unaltered
+    }
+    url = server() + 'strip_html'
+    resp_meta, resp_body = H.request(url, 'POST',
+                                     body=json.dumps(request_data))
+    assert resp_meta.status == 200
+    assert_same_jsons(expected_result, resp_body)


### PR DESCRIPTION
Per https://issues.dp.la/issues/7636, this is a second stab at stripping HTML tags from a given record.

It seems best to implement this as a pipeline module, as is being done now.

It also seems best to try to strip all string fields, per Amy's comment in the ticket.

The pipeline module is applied initially to the Smithsonian profile, because issues with Smithsonian's titles prompted the creation of issue #7636.
