### PR TITLE
Have save_records.py use sync_qa_views (fixes #7680)

### DIFF
--- a/scripts/save_records.py
+++ b/scripts/save_records.py
@@ -33,6 +33,11 @@ def main(argv):
     parser = define_arguments()
     args = parser.parse_args(argv[1:])
 
+    # ConfigParser.ConfigParser().getboolean() expects a string
+    config = ConfigParser.ConfigParser({"SyncQAViews": "True"})
+    config.readfp(open('akara.ini'))
+    sync_qa_views = config.getboolean('CouchDb', 'SyncQAViews')
+
     batch_size = 500
 
     couch = Couch()
@@ -101,7 +106,7 @@ def main(argv):
 
             if total_items > sync_point:
                 print "Syncing views"
-                couch.sync_views(couch.dpla_db.name)
+                couch.sync_views(couch.dpla_db.name, sync_qa_views)
                 sync_point = total_items + 10000
 
             # Set docs for the next iteration
@@ -120,7 +125,7 @@ def main(argv):
             total_collections += len(docs) - items
             print "Saved %s documents" % (total_items + total_collections)
             print "Syncing views"
-            couch.sync_views(couch.dpla_db.name)
+            couch.sync_views(couch.dpla_db.name, sync_qa_views)
 
     print "Total items: %s" % total_items
     print "Total collections: %s" % total_collections

--- a/test/test_couch.py
+++ b/test/test_couch.py
@@ -76,8 +76,8 @@ class CouchTest(Couch):
         del self.server[TEST_DASHBOARD_DB]
         self.dpla_db = self.server.create(TEST_DPLA_DB)
         self.dashboard_db = self.server.create(TEST_DASHBOARD_DB)
-        self.sync_views("dpla")
-        self.sync_views("dashboard")
+        self.sync_views("dpla", True)
+        self.sync_views("dashboard", True)
 
     def get_provider_backups(self):
         return [db for db in self.server if db.startswith(PROVIDER + "_")]
@@ -113,8 +113,8 @@ def couch_setup():
     couch = CouchTest(server_url=SERVER_URL,
                       dpla_db_name=TEST_DPLA_DB,
                       dashboard_db_name=TEST_DASHBOARD_DB)
-    couch.sync_views("dpla")
-    couch.sync_views("dashboard")
+    couch.sync_views("dpla", True)
+    couch.sync_views("dashboard", True)
     couch._sync_test_views()
 
 @nottest


### PR DESCRIPTION
Also explicitly sets the sync_qa_views parameter when running Couch tests
