### PR TITLE
Refactor Couch() object for sync_qa_views property (ref #7545)

### DIFF
--- a/lib/couch.py
+++ b/lib/couch.py
@@ -33,13 +33,16 @@ class Couch(object):
             views_directory: The path where the view JavaScript files
                              are located.
             batch_size: The batch size to use with iterview
+            sync_qa_views: Boolean; determines whether QA views get synced
         """
-        config = ConfigParser.ConfigParser({"LogLevel": "INFO"})
+        config = ConfigParser.ConfigParser({"LogLevel": "INFO",
+                                            "SyncQAViews": "True"})
         config.readfp(open(config_file))
         url = config.get("CouchDb", "Url")
         username = config.get("CouchDb", "Username")
         password = config.get("CouchDb", "Password")
         log_level = config.get("CouchDb", "LogLevel")
+        sync_qa_views = config.getboolean("CouchDb", "SyncQAViews")
 
         if not kwargs:
             dpla_db_name = "dpla"
@@ -47,6 +50,7 @@ class Couch(object):
         else:
             dpla_db_name = kwargs.get("dpla_db_name")
             dashboard_db_name = kwargs.get("dashboard_db_name")
+            sync_qa_views = kwargs.get("sync_qa_views", True)
 
         bulk_download_db_name = "bulk_download"
 
@@ -60,6 +64,7 @@ class Couch(object):
         self.bulk_download_db = self._get_db(bulk_download_db_name)
         self.views_directory = "couchdb_views"
         self.batch_size = 500
+        self.sync_qa_views = sync_qa_views
 
         self.logger = logging.getLogger("couch")
         handler = logging.FileHandler("logs/couch.log")
@@ -84,7 +89,7 @@ class Couch(object):
         """Return the result of the given view in the "dpla" database"""
         return self.dpla_db.view(viewname, None, **options)
 
-    def sync_views(self, db_name, sync_qa_views=True):
+    def sync_views(self, db_name):
         """Fetches design documents from the views_directory, saves/updates
            them in the appropriate database, then build the views. 
         """
@@ -95,15 +100,18 @@ class Couch(object):
                                  "bulk_download_db_all_contributor_docs.js"]
         if db_name == "dpla":
             db = self.dpla_db
-            if sync_qa_views:
+            if self.sync_qa_views:
+                self.logger.debug("QA views will be synced.")
                 build_views_from_file.append("dpla_db_qa_reports.js")
+            else:
+                self.logger.debug("QA views will NOT be synced.")
         elif db_name == "dashboard":
             db = self.dashboard_db
         elif db_name == "bulk_download":
             db = self.bulk_download_db
 
         for file in os.listdir(self.views_directory):
-            if file.startswith(db_name):
+            if file.startswith(db_name) and file in build_views_from_file:
                 fname = os.path.join(self.views_directory, file)
                 with open(fname, "r") as f:
                     s = f.read().replace("\n", "")
@@ -120,21 +128,20 @@ class Couch(object):
                     db[design_doc["_id"]] = design_doc
 
                 # Build views
-                if file in build_views_from_file:
-                    design_doc_name = design_doc["_id"].split("_design/")[-1]
-                    real_views = (v for v in design_doc["views"] if v != "lib")
-                    for view in real_views:
-                        view_path = "%s/%s" % (design_doc_name, view)
-                        start = time.time()
-                        try:
-                            for doc in db.view(view_path, limit=0):
-                                pass
-                            self.logger.debug("Built %s view %s in %s seconds"
-                                              % (db.name, view_path,
-                                                 time.time() - start))
-                        except Exception, e:
-                            self.logger.error("Error building %s view %s: %s" %
-                                              (db.name, view_path, e))
+                design_doc_name = design_doc["_id"].split("_design/")[-1]
+                real_views = (v for v in design_doc["views"] if v != "lib")
+                for view in real_views:
+                    view_path = "%s/%s" % (design_doc_name, view)
+                    start = time.time()
+                    try:
+                        for doc in db.view(view_path, limit=0):
+                            pass
+                        self.logger.debug("Built %s view %s in %s seconds"
+                                          % (db.name, view_path,
+                                             time.time() - start))
+                    except Exception, e:
+                        self.logger.error("Error building %s view %s: %s" %
+                                          (db.name, view_path, e))
 
     def update_ingestion_doc(self, ingestion_doc, **kwargs):
         for prop, value in kwargs.items():

--- a/scripts/save_records.py
+++ b/scripts/save_records.py
@@ -9,7 +9,6 @@ import os
 import sys
 import shutil
 import argparse
-import ConfigParser
 from akara import logger
 from datetime import datetime
 from amara.thirdparty import json
@@ -32,11 +31,6 @@ def define_arguments():
 def main(argv):
     parser = define_arguments()
     args = parser.parse_args(argv[1:])
-
-    # ConfigParser.ConfigParser().getboolean() expects a string
-    config = ConfigParser.ConfigParser({"SyncQAViews": "True"})
-    config.readfp(open('akara.ini'))
-    sync_qa_views = config.getboolean('CouchDb', 'SyncQAViews')
 
     batch_size = 500
 
@@ -106,7 +100,7 @@ def main(argv):
 
             if total_items > sync_point:
                 print "Syncing views"
-                couch.sync_views(couch.dpla_db.name, sync_qa_views)
+                couch.sync_views(couch.dpla_db.name)
                 sync_point = total_items + 10000
 
             # Set docs for the next iteration
@@ -125,7 +119,7 @@ def main(argv):
             total_collections += len(docs) - items
             print "Saved %s documents" % (total_items + total_collections)
             print "Syncing views"
-            couch.sync_views(couch.dpla_db.name, sync_qa_views)
+            couch.sync_views(couch.dpla_db.name)
 
     print "Total items: %s" % total_items
     print "Total collections: %s" % total_collections

--- a/scripts/sync_couch_views.py
+++ b/scripts/sync_couch_views.py
@@ -15,10 +15,6 @@ import argparse
 import ConfigParser
 from dplaingestion.couch import Couch
 
-# ConfigParser.ConfigParser().getboolean() expects a string
-config = ConfigParser.ConfigParser({"SyncQAViews": "True"})
-config.readfp(open('akara.ini'))
-
 def define_arguments():
     """Defines command line arguments for the current script"""
     parser = argparse.ArgumentParser()
@@ -32,11 +28,10 @@ def define_arguments():
 def main(argv):
     parser = define_arguments()
     args = parser.parse_args(argv[1:])
-    sync_qa_views = config.getboolean('CouchDb', 'SyncQAViews')
     couch = Couch()
     database_names = ["dpla", "dashboard", "bulk_download"]
     if args.database_name in database_names:
-        couch.sync_views(args.database_name, sync_qa_views)
+        couch.sync_views(args.database_name)
     else:
         print >> sys.stderr, "The database_name parameter should be " + \
                              "either %s" % " or ".join(database_names)

--- a/test/test_couch.py
+++ b/test/test_couch.py
@@ -76,8 +76,8 @@ class CouchTest(Couch):
         del self.server[TEST_DASHBOARD_DB]
         self.dpla_db = self.server.create(TEST_DPLA_DB)
         self.dashboard_db = self.server.create(TEST_DASHBOARD_DB)
-        self.sync_views("dpla", True)
-        self.sync_views("dashboard", True)
+        self.sync_views("dpla")
+        self.sync_views("dashboard")
 
     def get_provider_backups(self):
         return [db for db in self.server if db.startswith(PROVIDER + "_")]
@@ -113,8 +113,8 @@ def couch_setup():
     couch = CouchTest(server_url=SERVER_URL,
                       dpla_db_name=TEST_DPLA_DB,
                       dashboard_db_name=TEST_DASHBOARD_DB)
-    couch.sync_views("dpla", True)
-    couch.sync_views("dashboard", True)
+    couch.sync_views("dpla")
+    couch.sync_views("dashboard")
     couch._sync_test_views()
 
 @nottest


### PR DESCRIPTION
This refactors `Couch()` to add a new `sync_qa_views` property that can be set either from `akara.ini` or through the `kwargs` when instantiating a new object. This should address the issue that we saw in PROD where _all_ views were being synced during steps like save, remove deleted records, etc...
