### PR TITLE
Fix UTC datestamp regression (fixes #7699)

### DIFF
--- a/lib/utilities.py
+++ b/lib/utilities.py
@@ -124,6 +124,9 @@ def remove_all_brackets_and_strip(d):
 def strip_unclosed_brackets(s):
     return re.sub(r'\[(?![^\]]*?\])', '', s)
 
-def iso_utc_with_tz(dt=datetime.utcnow()):
-    """Given a UTC datetime, return an ISO 8601-conformant string w/ timezone"""
+def iso_utc_with_tz(dt=None):
+    """Given a UTC datetime, return an ISO 8601-conformant string w/ timezone
+    If None, use datetime.datetime.utcnow() as the default."""
+    if not dt:
+        dt = datetime.utcnow()
     return dt.isoformat() + "Z"

--- a/test/test_iso_utc_with_tz.py
+++ b/test/test_iso_utc_with_tz.py
@@ -1,12 +1,18 @@
 import sys
 from datetime import datetime
 from dplaingestion.utilities import iso_utc_with_tz
+from time import sleep
 
 def test_iso_utc_with_tz():
     """iso_utc_with_tz() should yield a UTC datetime as a string with timezone symbol Z"""
     utc_now = datetime.utcnow()
     utc_now_iso_string_with_tz = utc_now.isoformat() + "Z"
     assert utc_now_iso_string_with_tz == iso_utc_with_tz(utc_now)
+    # The following was added because of the regression described in #7699.
+    time1 = iso_utc_with_tz()
+    sleep(1)
+    time2 = iso_utc_with_tz() 
+    assert time1 != time2
 
 if __name__ == "__main__":
     raise SystemExit("Use nosetest")


### PR DESCRIPTION
`iso_utc_with_tz()` introduced a regression where all datestamps are the same unless a `datetime.datetime` object is passed to the function. It seems as though that `iso_utc_with_tz()`'s default argument is a function (`datetime.datetime.utcnow()`), whose results were cached. This commit fixes that.
