### PR TITLE
Fix dedupe value exception (#7700)

### DIFF
--- a/lib/akamod/dedup_value.py
+++ b/lib/akamod/dedup_value.py
@@ -9,9 +9,8 @@ import re
                 'application/json')
 def dedup_value(body, ctype, action="dedup_value", prop=None):
     '''
-    Service that accepts a JSON document and enriches the prop field of that document by:
-
-    a) Removing duplicates
+    Service that accepts a JSON document and enriches the prop field of that
+    document by removing duplicate array elements
     '''
 
     if prop:
@@ -27,9 +26,16 @@ def dedup_value(body, ctype, action="dedup_value", prop=None):
                 v = getprop(data, p)
                 if isinstance(v, list):
                     # Remove whitespace, periods, parens, brackets
-                    clone = [re.sub("[ \.\(\)\[\]\{\}]", "", s).lower() for s in v]
+                    clone = [_stripped(s) for s in v if _stripped(s)]
                     # Get index of unique values
-                    index = list(set([clone.index(s) for s in list(set(clone))]))
+                    index = list(set([clone.index(s)
+                                      for s in list(set(clone))]))
                     setprop(data, p, [v[i] for i in index])
 
     return json.dumps(data)
+
+def _stripped(thing):
+    if isinstance(thing, basestring):
+        return re.sub("[ \.\(\)\[\]\{\}]", "", thing).lower()
+    else:
+        return str(thing)

--- a/test/test_dedup_value.py
+++ b/test/test_dedup_value.py
@@ -60,3 +60,25 @@ def test_dedup_value2():
     resp, content = _get_server_response(json.dumps(INPUT), props)
     assert resp.status == 200
     assert_same_jsons(INPUT, content)
+
+def test_dedup_value_with_nonstring_vals():
+    """dedup_value handles list elements that are not strings"""
+
+    props = "subject"
+    INPUT = {
+        "subject": [
+            "The subject",
+            None,
+            {"name": "Another subject"},
+            "[The subject]"]
+    }
+    EXPECTED = {
+        "subject": [
+            "The subject",
+            None,
+            {"name": "Another subject"}
+        ]
+    }
+    resp, content = _get_server_response(json.dumps(INPUT), props)
+    assert resp.status == 200
+    assert_same_jsons(EXPECTED, content)


### PR DESCRIPTION
The dedupe_value pipeline module was generating uncaught exceptions because it was incorrectly assuming that all elements in the array it evaluates are strings.

See https://issues.dp.la/issues/7700
