### PR TITLE
Parallelize tests on Travis to isolate those connecting externally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,11 @@ python:
 install:
   - pip install -r requirements.txt --use-mirrors
   - python setup.py install
+
+# use ENVs to isolate network tests, which, if slow, can cause build errors
+env:
+  - TRAVIS_NOSE_CONFIG='!travis_exclude,!uses_network'
+  - TRAVIS_NOSE_CONFIG='!travis_exclude,uses_network'
+
 # command to run tests
-script: nosetests -v -a '!travis_exclude'
+script: nosetests -v -a $TRAVIS_NOSE_CONFIG


### PR DESCRIPTION
We see frequent build errors on TravisCI when network-heavy tests (e.g testing fetcher classes) take a while to complete. This separates the tests running in two distinct Travis environments to speed things up a bit.
