### PR TITLE
Override DigitalNCMapper super's map_format

### DIFF
--- a/lib/mappers/digitalnc_mapper.py
+++ b/lib/mappers/digitalnc_mapper.py
@@ -59,6 +59,9 @@ class DigitalNCMapper(OAIMODSMapper):
 
             self.update_source_resource(self.clean_dict(_dict))
 
+    def map_format(self):
+        pass
+
     def map_format_and_spec_type(self):
         prop = self.root_key + "physicalDescription"
         _dict = {


### PR DESCRIPTION
The OAIMODSMapper's map_format method was being called and an exception thrown since this method expects an authority_condition parameter.
