### PR TITLE
Add strip_html pipeline module to all profiles (#7636)

### DIFF
--- a/profiles/artstor.pjs
+++ b/profiles/artstor.pjs
@@ -49,6 +49,7 @@
     "enrichments_item": [
         "/select-id?prop=id",
         "/dpla_mapper?mapper_type=dublin_core",
+        "/strip_html",
         "/set_context",
         "/unset_prop?prop=sourceResource%2Fspatial",
         "/decode_html?prop=sourceResource%2Fsubject",

--- a/profiles/bhl.pjs
+++ b/profiles/bhl.pjs
@@ -16,6 +16,7 @@
     "enrichments_item": [
         "/select-id",
         "/dpla_mapper?mapper_type=dublin_core",
+        "/strip_html",
         "/set_context",
         "/shred?prop=sourceResource%2Fcontributor%2CsourceResource%2Fcreator%2CsourceResource%2Fdate",
         "/shred?prop=sourceResource%2Flanguage%2CsourceResource%2Fpublisher%2CsourceResource%2Frelation",

--- a/profiles/bpl.pjs
+++ b/profiles/bpl.pjs
@@ -15,6 +15,7 @@
     "enrichments_item": [
         "/select-id?prop=header%2Fidentifier",
         "/dpla_mapper?mapper_type=bpl",
+        "/strip_html",
         "/set_context",
         "/shred?prop=sourceResource%2Fcontributor%2CsourceResource%2Fcreator%2CsourceResource%2Fdate",
         "/shred?prop=sourceResource%2Flanguage%2CsourceResource%2Fpublisher%2CsourceResource%2Frelation",

--- a/profiles/clemson.pjs
+++ b/profiles/clemson.pjs
@@ -15,6 +15,7 @@
     "enrichments_item": [
         "/select-id",
         "/dpla_mapper?mapper_type=scdl",
+        "/strip_html",
         "/set_context",
         "/shred?prop=sourceResource%2Fcontributor%2CsourceResource%2Fcreator%2CsourceResource%2Fdate",
         "/shred?prop=sourceResource%2Flanguage%2CsourceResource%2Fpublisher%2CsourceResource%2Frelation",

--- a/profiles/david_rumsey.pjs
+++ b/profiles/david_rumsey.pjs
@@ -16,6 +16,7 @@
     "enrichments_item": [
         "/select-id",
         "/dpla_mapper?mapper_type=dublin_core",
+        "/strip_html",
         "/set_context",
         "/shred?prop=sourceResource%2Fcontributor%2CsourceResource%2Fcreator%2CsourceResource%2Fdate",
         "/shred?prop=sourceResource%2Flanguage%2CsourceResource%2Fpublisher%2CsourceResource%2Frelation",

--- a/profiles/digitalnc.pjs
+++ b/profiles/digitalnc.pjs
@@ -15,6 +15,7 @@
     "enrichments_item": [
         "/select-id?prop=header%2Fidentifier",
         "/dpla_mapper?mapper_type=digitalnc",
+        "/strip_html",
         "/set_context",
         "/shred?prop=sourceResource%2Fdate&delim=%2C",
         "/enrich-subject",

--- a/profiles/georgia.pjs
+++ b/profiles/georgia.pjs
@@ -14,6 +14,7 @@
     "enrichments_item": [
         "/select-id",
         "/dpla_mapper?mapper_type=dublin_core",
+        "/strip_html",
         "/set_context",
         "/unset_prop?prop=sourceResource%2Fdate",
         "/copy_prop?prop=originalRecord%2Fsource&to_prop=sourceResource%2Fdescription",

--- a/profiles/getty.pjs
+++ b/profiles/getty.pjs
@@ -21,6 +21,7 @@
     "enrichments_item": [
         "/select-id?prop=_id",
         "/dpla_mapper?mapper_type=getty",
+        "/strip_html",
         "/set_context",
         "/shred?prop=sourceResource%2Fcontributor%2CsourceResource%2Fidentifier%2CsourceResource%2Flanguage",
         "/shred?prop=sourceResource%2Fpublisher%2CsourceResource%2Frelation%2CsourceResource%2Fsubject%2CsourceResource%2Ftitle",

--- a/profiles/gpo.pjs
+++ b/profiles/gpo.pjs
@@ -15,6 +15,7 @@
     "enrichments_item": [
         "/select-id?prop=header%2Fidentifier",
         "/dpla_mapper?mapper_type=gpo",
+        "/strip_html",
         "/set_context",
         "/dedup_value?prop=sourceResource%2Ftemporal%2CsourceResource%2Fspatial",
         "/cleanup_value",

--- a/profiles/harvard.pjs
+++ b/profiles/harvard.pjs
@@ -21,6 +21,7 @@
     "enrichments_item": [
         "/select-id?prop=header%2Fidentifier",
         "/dpla_mapper?mapper_type=harvard",
+        "/strip_html",
         "/set_context",
         "/set_prop?prop=sourceResource%2Frights&value=Held%20in%20the%20collections%20of%20Harvard%20University%2E",
         "/set_prop?prop=sourceResource%2FstateLocatedIn&value=Massachusetts",

--- a/profiles/hathi.pjs
+++ b/profiles/hathi.pjs
@@ -13,6 +13,7 @@
     "enrichments_item": [
         "/select-id?prop=_id",
         "/dpla_mapper?mapper_type=hathi",
+        "/strip_html",
         "/set_context",
         "/shred?prop=sourceResource%2Flanguage%2CsourceResource%2Fspatial",
         "/dedup_value?prop=sourceResource%2Fspatial",

--- a/profiles/ia.pjs
+++ b/profiles/ia.pjs
@@ -48,6 +48,7 @@
     "enrichments_item": [
         "/select-id?prop=_id",
         "/dpla_mapper?mapper_type=ia",
+        "/strip_html",
         "/set_context",
         "/ia-set-rights",
         "/cleanup_value",

--- a/profiles/kentucky.pjs
+++ b/profiles/kentucky.pjs
@@ -14,6 +14,7 @@
     "enrichments_item": [
         "/select-id", 
         "/dpla_mapper?mapper_type=dublin_core",
+        "/strip_html",
         "/set_context",
         "/unset_prop?prop=collection",
         "/unset_prop?prop=sourceResource%2Fcontributor",

--- a/profiles/minnesota.pjs
+++ b/profiles/minnesota.pjs
@@ -15,6 +15,7 @@
     "enrichments_item": [
         "/select-id",
         "/dpla_mapper?mapper_type=mdl",
+        "/strip_html",
         "/set_context",
         "/shred?prop=sourceResource%2Fcontributor%2CsourceResource%2Fcreator%2CsourceResource%2Fdate",
         "/shred?prop=sourceResource%2Flanguage%2CsourceResource%2Frelation%2CsourceResource%2Fspatial",

--- a/profiles/mwdl.pjs
+++ b/profiles/mwdl.pjs
@@ -25,6 +25,7 @@
     "enrichments_item": [
         "/select-id?prop=_id", 
         "/dpla_mapper?mapper_type=mwdl",
+        "/strip_html",
         "/set_context",
         "/shred?prop=sourceResource%2Fcontributor%2CsourceResource%2Fcreator%2CsourceResource%2Fdate",
         "/shred?prop=sourceResource%2Flanguage%2CsourceResource%2Fpublisher%2CsourceResource%2Frelation",

--- a/profiles/nara.pjs
+++ b/profiles/nara.pjs
@@ -13,6 +13,7 @@
     "enrichments_item": [
         "/select-id?prop=_id", 
         "/dpla_mapper?mapper_type=nara",
+        "/strip_html",
         "/set_context",
         "/shred?prop=sourceResource%2Fcontributor%2CsourceResource%2Fcreator%2CsourceResource%2Fdate", 
         "/shred?prop=sourceResource%2Flanguage%2CsourceResource%2Fpublisher%2CsourceResource%2Frelation", 

--- a/profiles/nypl.pjs
+++ b/profiles/nypl.pjs
@@ -22,6 +22,7 @@
     "enrichments_item": [
         "/select-id?prop=_id",
         "/dpla_mapper?mapper_type=nypl",
+        "/strip_html",
         "/set_context",
         "/nypl_identify_object",
         "/cleanup_value",

--- a/profiles/scdl-charleston.pjs
+++ b/profiles/scdl-charleston.pjs
@@ -15,6 +15,7 @@
     "enrichments_item": [
         "/select-id", 
         "/dpla_mapper?mapper_type=charleston",
+        "/strip_html",
         "/set_context",
         "/shred?prop=sourceResource%2Fcontributor%2CsourceResource%2Fcreator%2CsourceResource%2Fdate",
         "/shred?prop=sourceResource%2Flanguage%2CsourceResource%2Fpublisher%2CsourceResource%2Frelation",

--- a/profiles/scdl-usc.pjs
+++ b/profiles/scdl-usc.pjs
@@ -15,6 +15,7 @@
     "enrichments_item": [
         "/select-id", 
         "/dpla_mapper?mapper_type=scdl",
+        "/strip_html",
         "/set_context",
         "/shred?prop=sourceResource%2Fcontributor%2CsourceResource%2Fcreator%2CsourceResource%2Fdate",
         "/shred?prop=sourceResource%2Flanguage%2CsourceResource%2Fpublisher%2CsourceResource%2Frelation",

--- a/profiles/scdl.pjs
+++ b/profiles/scdl.pjs
@@ -15,6 +15,7 @@
     "enrichments_item": [
         "/select-id",
         "/dpla_mapper?mapper_type=scdl",
+        "/strip_html",
         "/set_context",
         "/shred?prop=sourceResource%2Fcontributor%2CsourceResource%2Fcreator%2CsourceResource%2Fdate",
         "/shred?prop=sourceResource%2Flanguage%2CsourceResource%2Fpublisher%2CsourceResource%2Frelation",

--- a/profiles/texas.pjs
+++ b/profiles/texas.pjs
@@ -319,6 +319,7 @@
     "enrichments_item": [
         "/select-id?prop=header%2Fidentifier",
         "/dpla_mapper?mapper_type=untl",
+        "/strip_html",
         "/set_context",
         "/shred?prop=sourceResource%2Fsubject&delim=%20-%20",
         "/cleanup_value",

--- a/profiles/uiuc.pjs
+++ b/profiles/uiuc.pjs
@@ -36,6 +36,7 @@
     "enrichments_item": [
         "/select-id",
         "/dpla_mapper?mapper_type=uiuc",
+        "/strip_html",
         "/set_context",
         "/shred?prop=sourceResource%2Fcontributor%2CsourceResource%2Fcreator%2CsourceResource%2Fdate",
         "/shred?prop=sourceResource%2Flanguage%2CsourceResource%2Fpublisher%2CsourceResource%2Frelation",

--- a/profiles/uiuc_book.pjs
+++ b/profiles/uiuc_book.pjs
@@ -19,6 +19,7 @@
     "enrichments_item": [
         "/select-id?prop=header%2Fidentifier",
         "/dpla_mapper?mapper_type=uiuc_marc",
+        "/strip_html",
         "/set_context",
         "/shred?prop=sourceResource%2Flanguage%2CsourceResource%2Fspatial",
         "/cleanup_value",

--- a/profiles/usc.pjs
+++ b/profiles/usc.pjs
@@ -54,6 +54,7 @@
     "enrichments_item": [
         "/select-id", 
         "/dpla_mapper?mapper_type=dublin_core",
+        "/strip_html",
         "/set_context",
         "/unset_prop?prop=sourceResource%2Fdate",
         "/shred?prop=sourceResource%2Fcontributor%2CsourceResource%2Fcreator%2CsourceResource%2Fspatial", 

--- a/profiles/virginia.pjs
+++ b/profiles/virginia.pjs
@@ -24,6 +24,7 @@
     "enrichments_item": [
         "/select-id?prop=_id",
         "/dpla_mapper?mapper_type=uva",
+        "/strip_html",
         "/set_context",
         "/copy_prop?prop=sourceResource%2Frights&to_prop=hasView%2Frights",
         "/cleanup_value",

--- a/profiles/virginia_books.pjs
+++ b/profiles/virginia_books.pjs
@@ -18,6 +18,7 @@
     "enrichments_item": [
         "/select-id?prop=_id",
         "/dpla_mapper?mapper_type=uva",
+        "/strip_html",
         "/set_context",
         "/copy_prop?prop=sourceResource%2Frights&to_prop=hasView%2Frights",
         "/cleanup_value",


### PR DESCRIPTION
This had been added to Smithsonian previously.  Per the ticket, and
after watching it work successfully on this and a couple of profiles
still in development, it appears OK to apply to all other profiles.
