### PR TITLE
MAPv3.1/temporal-related indexing fixes (refs #7704)

### DIFF
--- a/lib/mapv3.py
+++ b/lib/mapv3.py
@@ -203,7 +203,9 @@ MAPV3_SCHEMAS = {
                             },
                         }
                     },
-                    "temporal": {"$ref": "#/definitions/arrayOrString"},
+                    "temporal": {
+                        "oneOf": array_or_item({"$ref": "#/definitions/date"})
+                    },
                     "title": {"$ref": "#/definitions/arrayOrString"},
                     "type": {
                         "oneOf": array_or_item({"$ref": "#/definitions/type"})

--- a/profiles/mwdl.pjs
+++ b/profiles/mwdl.pjs
@@ -35,6 +35,7 @@
         "/move_date_values?prop=sourceResource%2Fspatial",
         "/capitalize_value",
         "/enrich_earliest_date",
+        "/enrich_date",
         "/enrich-subject",
         "/enrich-type",
         "/enrich-format",

--- a/profiles/nypl.pjs
+++ b/profiles/nypl.pjs
@@ -28,6 +28,7 @@
         "/capitalize_value",
         "/enrich-subject",
         "/enrich_earliest_date",
+        "/enrich_date",
         "/enrich-type",
         "/enrich-format",
         "/enrich_location",


### PR DESCRIPTION
Changes to the MWDL profile in 906916dff66899a23ae4fbce05440f1afc801ab4 are causing the records to fail on indexing. This commit readds the `enrich_date` steps and changes the validation so it matches how `sourceResource.date` is defined.
