### PR TITLE
Ensure `dataProvider` gets set (fixes #7679)

### DIFF
--- a/lib/mappers/gpo_mapper.py
+++ b/lib/mappers/gpo_mapper.py
@@ -232,10 +232,6 @@ class GPOMapper(MARCMapper):
         if date:
             self.update_source_resource({"date": date})
 
-    def update_data_provider(self):
-        data_provider = self._get_mapped_value("provider/name")
-        self.mapped_data.update({"dataProvider": data_provider})
-
     def update_description(self):
         description = []
         if (not self.description["310"] and self.leader[7] == "s" and
@@ -276,7 +272,6 @@ class GPOMapper(MARCMapper):
         self.update_date()
         self.update_description()
         self.update_rights()
-        self.update_data_provider()
         self.update_object()
 
     def map(self):

--- a/profiles/artstor.pjs
+++ b/profiles/artstor.pjs
@@ -77,6 +77,7 @@
         "/set_type_from_physical_format",
         "/copy_prop?prop=sourceResource%2Fpublisher&to_prop=dataProvider",
         "/unset_prop?prop=sourceResource%2Frelation",
+        "/copy_prop?prop=provider%2Fname&to_prop=dataProvider&skip_if_exists=True",
         "/validate_mapv3"
     ],
     "thresholds": {                                                             

--- a/profiles/bpl.pjs
+++ b/profiles/bpl.pjs
@@ -33,6 +33,7 @@
         "/set_prop?prop=provider%2Fname&value=Digital%20Commonwealth",
         "/set_prop?prop=sourceResource%2FstateLocatedIn&value=Massachusetts",
         "/enrich_location?prop=sourceResource%2FstateLocatedIn",
+        "/copy_prop?prop=provider%2Fname&to_prop=dataProvider&skip_if_exists=True",
         "/unset_prop?prop=_id&condition_prop=sourceResource%2Ftitle&condition=finding_aid_title",
         "/validate_mapv3"
     ],

--- a/profiles/digitalnc.pjs
+++ b/profiles/digitalnc.pjs
@@ -28,6 +28,7 @@
         "/enrich_language",
         "/set_prop?prop=sourceResource%2FstateLocatedIn&value=North%20Carolina",
         "/enrich_location?prop=sourceResource%2FstateLocatedIn",
+        "/copy_prop?prop=provider%2Fname&to_prop=dataProvider&skip_if_exists=True",
         "/validate_mapv3"
     ],
     "thresholds": {                                                             

--- a/profiles/getty.pjs
+++ b/profiles/getty.pjs
@@ -32,6 +32,7 @@
         "/enrich-type",
         "/enrich_language",
         "/set_type_from_physical_format",
+        "/copy_prop?prop=provider%2Fname&to_prop=dataProvider&skip_if_exists=True",
         "/validate_mapv3"
     ],
     "thresholds": {

--- a/profiles/gpo.pjs
+++ b/profiles/gpo.pjs
@@ -27,6 +27,7 @@
         "/enrich_location",
         "/geocode",
         "/enrich_language",
+        "/copy_prop?prop=provider%2Fname&to_prop=dataProvider&skip_if_exists=True",
         "/validate_mapv3"
     ],
     "thresholds": {

--- a/profiles/hathi.pjs
+++ b/profiles/hathi.pjs
@@ -29,6 +29,7 @@
         "/unset_prop?prop=_id&condition=hathi_exclude&condition_prop=dataProvider",
         "/hathi_identify_object",
         "/set_prop?prop=provider&_dict=True&value=%7B%22%40id%22%3A%22http%3A%2F%2Fdp.la%2Fapi%2Fcontributor%2Fhathitrust%22%2C%22name%22%3A%22HathiTrust%22%7D",
+        "/copy_prop?prop=provider%2Fname&to_prop=dataProvider&skip_if_exists=True",
         "/validate_mapv3"
     ],
     "set_provider": [

--- a/profiles/kentucky.pjs
+++ b/profiles/kentucky.pjs
@@ -38,6 +38,7 @@
         "/unset_prop?prop=dataProvider",
         "/copy_prop?prop=sourceResource%2Fpublisher&to_prop=dataProvider",
         "/unset_prop?prop=sourceResource%2Fpublisher",
+        "/copy_prop?prop=provider%2Fname&to_prop=dataProvider&skip_if_exists=True",
         "/geocode",
         "/validate_mapv3"
     ],

--- a/profiles/minnesota.pjs
+++ b/profiles/minnesota.pjs
@@ -36,6 +36,7 @@
         "/enrich_language",
         "/mdl_state_located_in",
         "/enrich_location?prop=sourceResource%2FstateLocatedIn",
+        "/copy_prop?prop=provider%2Fname&to_prop=dataProvider&skip_if_exists=True",
         "/validate_mapv3"
     ],
     "thresholds": {

--- a/profiles/nypl.pjs
+++ b/profiles/nypl.pjs
@@ -36,6 +36,7 @@
         "/geocode",
         "/enrich_language",
         "/enrich_location?prop=sourceResource%2FstateLocatedIn",
+        "/copy_prop?prop=provider%2Fname&to_prop=dataProvider&skip_if_exists=True",
         "/validate_mapv3"
     ],
     "thresholds": {

--- a/profiles/texas.pjs
+++ b/profiles/texas.pjs
@@ -332,6 +332,7 @@
         "/texas_enrich_location",
         "/geocode",
         "/enrich_language",
+        "/copy_prop?prop=provider%2Fname&to_prop=dataProvider&skip_if_exists=True",
         "/validate_mapv3"
     ],
     "thresholds": {

--- a/profiles/uiuc_book.pjs
+++ b/profiles/uiuc_book.pjs
@@ -31,6 +31,7 @@
         "/enrich_location",
         "/geocode",
         "/enrich_language",
+        "/copy_prop?prop=provider%2Fname&to_prop=dataProvider&skip_if_exists=True",
         "/validate_mapv3"
     ],
     "thresholds": {

--- a/profiles/usc.pjs
+++ b/profiles/usc.pjs
@@ -77,6 +77,7 @@
         "/remove_list_values?prop=sourceResource%2Ftype&values=item",
         "/dedup_value?prop=sourceResource%2Ftype",
         "/unset_prop?prop=sourceResource%2Fcollection",
+        "/copy_prop?prop=provider%2Fname&to_prop=dataProvider&skip_if_exists=True",
         "/validate_mapv3"
     ],
     "thresholds": {


### PR DESCRIPTION
12 profiles were missing the `copy_prop` enrichment that copies `provider.name` to `dataProvider` if `dataProvider` is `null`. This commit also removes `GPOMapper.update_data_provider()` to prefer the solution using the `copy_prop` enrichment.
