### PR TITLE
Add Missouri Hub profile

### DIFF
--- a/akara.conf.template
+++ b/akara.conf.template
@@ -131,6 +131,8 @@ MODULES = [
     "dplaingestion.mappers.bpl_mapper",
     "dplaingestion.mappers.mwdl_mapper",
     "dplaingestion.mappers.getty_mapper",
+    "dplaingestion.mappers.primo_mapper",
+    "dplaingestion.mappers.missouri_mapper",
     "dplaingestion.akamod.enrich",
     "dplaingestion.akamod.enrich-subject",
     "dplaingestion.akamod.enrich-type",

--- a/lib/create_mapper.py
+++ b/lib/create_mapper.py
@@ -80,6 +80,10 @@ def create_mapper(mapper_type, data):
         from dplaingestion.mappers.dublin_core_mapper import DublinCoreMapper
         return DublinCoreMapper(data)
 
+    def _create_missouri_mapper(data):
+        from dplaingestion.mappers.missouri_mapper import MissouriMapper
+        return MissouriMapper(data)
+
     mappers = {
         'ia':           lambda d: _create_ia_mapper(d),
         'bpl':          lambda d: _create_bpl_mapper(d),
@@ -100,6 +104,7 @@ def create_mapper(mapper_type, data):
         'digitalnc':    lambda d: _create_digitalnc_mapper(d),
         'uiuc_marc':    lambda d: _create_uiuc_marc_mapper(d),
         'dublin_core':  lambda d: _create_dublin_core_mapper(d),
+        'missouri':     lambda d: _create_missouri_mapper(d)
     }
 
     return mappers.get(mapper_type)(data)

--- a/lib/mappers/missouri_mapper.py
+++ b/lib/mappers/missouri_mapper.py
@@ -1,0 +1,659 @@
+
+"""
+Missouri Hub Mapper 
+"""
+
+from akara import logger
+from dplaingestion.mappers.oai_mods_mapper import OAIMODSMapper
+from dplaingestion.textnode import textnode, NoTextNodeError
+from dplaingestion.utilities import iterify
+from dplaingestion.spectype import valid_spec_types
+
+
+class MissouriMapper(OAIMODSMapper):
+
+    def map_data_provider(self):
+        """Map dataProvider
+
+        In feed XML:
+            //record/metadata/mods/note[@type='ownership']
+        In body of mapper request JSON:
+            .note
+        """
+        note = iterify(self.provider_data.get('note'))
+        if note:
+            try:
+                ownership = [e for e in note
+                             if type(e) == dict and e['type'] == 'ownership']
+                if ownership:
+                    provider = ownership[0]
+                    self.mapped_data.update({'dataProvider': textnode(e)})
+            except (KeyError, NoTextNodeError):
+                # There was no note with a 'type' attribute, or there was, but
+                # it was an XML element lacking a text node.
+                pass
+
+    def map_creator(self):
+        """Map sourceResource.creator
+
+        In feed XML:
+            //record/metadata/mods/name/namePart[./role/roleTerm='creator']
+        In body of mapper request JSON:
+            .name like this:
+            {'namePart': 'Creator Name',
+             'role': {
+                 'roleTerm': {'#text': 'creator', 'type': 'text'}
+             }
+            }
+        """            
+        # only in MHM, SLU, and WUSTL collections
+        def creator_names(names):
+            """Creator names from name elements with creator role
+
+            Can pass a TypeError or KeyError.
+            """
+            for n in names:
+                try:
+                    if n['role']['roleTerm'] == 'creator' \
+                            or textnode(n['role']['roleTerm']) == 'creator':
+                        yield n['namePart']
+                except (KeyError, NoTextNodeError):
+                    # No name with a roleTerm of "creator," but it's not
+                    # required.
+                    pass
+        name = iterify(self.provider_data.get('name', []))
+        if name:
+            creators = [n for n in creator_names(name)]
+            if creators:
+                self.update_source_resource({'creator': creators})
+
+    def map_date(self):
+        """Map sourceResource.date
+
+        In feed XML:
+            //record/metadata/mods/originInfo/dateCreated[@keyDate='yes']
+            or
+            //record/metadata/mods/originInfo/dateIssued[@point='start']
+            or
+            //record/metadata/mods/originInfo/dateOther
+        In body of mapper request JSON:
+            .originInfo[].dateIssued like this:
+                {'point': 'start', '#text': '2014'}
+            or .originInfo[].dateCreated like this:
+                {'keyDate': 'yes', '#text': '2014'}
+            or .originInfo[].dateOther like this:
+                {'#text': '2014'}
+        """
+        # (FRBSTL uses <originInfo><dateIssued>;
+        # SLU, MDH, WUSTL use <originInfo><dateOther>
+        def first_date(els):
+            """Return first date string from originInfo elements"""
+            for el in els:
+                # Allow for each of the following elements to be an array of
+                # dicts or strings, or one on its own.
+                date_created = iterify(el.get('dateCreated', []))
+                date_issued = iterify(el.get('dateIssued', []))
+                date_other = iterify(el.get('dateOther', []))
+                sort_date = iterify(el.get('sortDate', []))
+                try:
+                    for d in date_created:
+                        if type(d) == dict and d.get('keyDate') == 'yes':
+                            return textnode(d)
+                    for d in date_issued:
+                        if type(d) == dict and d.get('point') == 'start':
+                            return textnode(d)
+                    # Nothing yet?  Take first dateOther, ignoring attributes:
+                    if date_other:
+                        return textnode(date_other[0])
+                    # OK, then take the first dateIssued we can get, ignoring
+                    # attribute ...
+                    if date_issued:
+                        return textnode(date_issued[0])
+                    # Still nothing?  Try sortDate:
+                    if sort_date:
+                        return textnode(sort_date[0])
+                except NoTextNodeError:
+                    # Weird, but date is not required.
+                    pass
+        origin_info = iterify(self.provider_data.get('originInfo', []))
+        if origin_info:
+            date = first_date(origin_info)
+            if date:
+                self.update_source_resource({'date': date})
+
+    def map_description(self):
+        """Map sourceResource.description
+
+        In feed XML:
+            //record/metadata/mods/note
+            ... where there's no 'type' attribute of 'ownership'
+        In body of mapper request JSON:
+            .note
+            ... with conditions above
+        """
+        def is_ownership_note(n):
+            """The given //note has attribute "type" == "ownership" """
+            try:
+                return n.get('type') == 'ownership'
+            except:
+                return False
+        def desc_string(n):
+            """The text node of the given //note or '' if it's empty"""
+            try:
+                return textnode(n)
+            except NoTextNodeError:
+                return ''
+        note = iterify(self.provider_data.get('note', []))
+        if note:
+            try:
+                desc = [desc_string(n) for n in note
+                        if not is_ownership_note(n) and desc_string(n)]
+                if desc:
+                    self.update_source_resource({'description': desc})
+            except IndexError:
+                # No appropriate notes.  Not required, so pass.
+                pass
+
+    def map_extent(self):
+        """Map sourceResource.extent
+
+        In feed XML:
+            //record/metadata/mods/physicalDescription/extent
+        In body of mapper request JSON:
+            .physicalDescription.extent, as in:
+            "physicalDescription": {
+                "extent": "3 files",
+                "xmlns:default": "http://www.loc.gov/mods/v3"
+            }
+        """
+        phys_desc = self.provider_data.get('physicalDescription')
+        if phys_desc and 'extent' in phys_desc:
+            self.update_source_resource({'extent': phys_desc['extent']})
+
+    def map_format(self):
+        """Map sourceResource.format
+
+        In feed XML:
+            //record/metadata/mods/physicalDescription/note
+            or
+            //record/metadata/mods/genre
+        In body of mapper request JSON:
+            "physicalDescription": {
+                "note": "the description"
+            }
+            ... That being theoretical; I haven't encountered it yet.
+            ... if there are attributes, note will have a text node, and
+                that will be used.
+            or
+            "genre": {
+                "#text": "book",
+                "xmlns:default": "http://www.loc.gov/mods/v3"
+            }
+            ... and "genre" could be a string if the element has no attribute.
+        """
+        def fmt_from_physdesc(phys_descs):
+            """Yield format strings from a list of physicalDescriptions"""
+            for pd in phys_descs:
+                if 'note' in pd:
+                    try:
+                        yield textnode(pd['note'])
+                    except NoTextNodeError:
+                        pass
+        genre = iterify(self.provider_data.get('genre', []))
+        phys_desc = iterify(self.provider_data.get('physicalDescription', []))
+        format = None
+        if genre:
+            format = [f for f in _genre_strings(genre)]
+        elif phys_desc:
+            format = [f for f in fmt_from_physdesc(phys_desc)]
+        if format:
+            self.update_source_resource({'format': format})
+
+    def map_identifier(self):
+        """Map sourceResource.identifier
+
+        In feed XML:
+            //record/metadata/mods/identifier
+        In body of mapper request JSON:
+            "identifier": [
+              {
+                "#text": "11504366",
+                "type": "oclc",
+                "xmlns:default": "http://www.loc.gov/mods/v3"
+              },
+              {
+                "#text": "27303118",
+                "type": "oclc",
+                "xmlns:default": "http://www.loc.gov/mods/v3"
+              }
+            ]
+            or
+            "identifier": {
+                "#text": "..."
+                ... etc ...
+            }
+            ... where "type" is optional, but if it's "oclc" we'll prepend
+            "OCLC:" to the identifier.
+        """
+        def idstrings(els):
+            for el in els:
+                try:
+                    if type(el) == dict and el.get('type') == 'oclc':
+                        t = 'OCLC:' + textnode(el).strip()
+                    else:
+                        t = textnode(el).strip()
+                    yield t
+                except NoTextNodeError:
+                    pass
+        identifier_el = iterify(self.provider_data.get('identifier', []))
+        identifiers = [i for i in idstrings(identifier_el)]
+        if identifiers:
+            self.update_source_resource({'identifier': identifiers})
+
+    def map_language(self):
+        """Map sourceResource.language
+
+        In feed XML:
+            //record/metadata/mods/language/languageTerm
+            ... or language without LanguageTerm
+        In body of mapper request JSON:
+            "language": {
+              "languageTerm": {
+                "#text": "Language Name",
+                "type": "text"
+              }
+            }
+            ... where "type" can be "code" with "#text" being a code
+            ... or
+            "language": {
+                "#text": "language code"
+                "xmlns:default": "..."
+            }
+        Language codes are sometimes semicolon-delimited, like "jpn; eng"
+        """
+        def lang_terms(els):
+            """Extract language terms from different elements"""
+            for el in els:
+                try:
+                    s = el.get('#text') or el['languageTerm'].get('#text')
+                    for t in s.split(';'):
+                        yield t.strip()
+                except KeyError:
+                    pass
+        language = iterify(self.provider_data.get('language', []))
+        if language:
+            languages = [t for t in lang_terms(language)]
+            if languages:
+                self.update_source_resource({'language': languages})
+
+    def map_publisher(self):
+        """Map sourceResource.publisher
+
+        In feed XML:
+            //record/metadata/mods/originInfo/publisher
+        In body of mapper request JSON:
+            "originInfo": [
+              {
+                "publisher": "Publisher One"
+              },
+              {
+                "publisher": "Publisher Two"
+              },
+              {
+                "someOtherField": "..."
+              }
+            ]
+        """
+        def pub_strings(els):
+            for el in els:
+                try:
+                    rv = textnode(el['publisher']).strip(' ,\n')
+                    if rv:
+                        yield rv
+                except (KeyError, NoTextNodeError):
+                    pass
+        origin_info = iterify(self.provider_data.get('originInfo', []))
+        if origin_info:
+            publishers = [p for p in pub_strings(origin_info)]
+            if publishers:
+                self.update_source_resource({'publisher': publishers})
+
+    def map_relation(self):
+        """Map sourceResource.relation
+
+        In feed XML:
+            //record/metadata/mods/relatedItem/location/url
+            or
+            //record/metadata/mods/relatedItem/titleInfo/title
+        In body of mapper request JSON:
+        {
+            "relatedItem": [
+                {
+                    "location": {
+                        "url": "http://fraser.stlouisfed.org/example/"
+                    },
+                    "recordInfo": {
+                        "recordIdentifier": "63"
+                    },
+                    "titleInfo": {
+                        "title": "The Title"
+                    },
+                    "type": "similarTo",
+                    "typeOfResource": "text",
+                    "xmlns:default": "http://www.loc.gov/mods/v3"
+                },
+                ...
+        }
+        """
+        def relation_strings(els):
+            """Yield all relation strings from a list of relatedItems"""
+            for el in els:
+                try:
+                    if 'location' in el and el['location']['url']:
+                        yield el['location']['url'].strip(' \n')
+                    if 'titleInfo' in el and el['titleInfo']['title']:
+                        yield el['titleInfo']['title'].strip(' \n')
+                except (KeyError, TypeError):
+                    # Not required, so pass
+                    pass
+        related_item = iterify(self.provider_data.get('relatedItem', []))
+        if related_item:
+            relations = [r for r in relation_strings(related_item)]
+            if relations:
+                self.update_source_resource({'relation': relations})
+
+    def map_rights(self):
+        """Map sourceResource.rights
+
+        In feed XML:
+            //record/metadata/mods/accessCondition
+        In body of mapper request JSON:
+            .accessCondition
+        """
+        # missing from MHM and FRBSTL collections
+        acc_cond = iterify(self.provider_data.get('accessCondition', []))
+        if acc_cond:
+            try:
+                rights = [textnode(r) for r in acc_cond]
+                if rights:
+                    self.update_source_resource({'rights': rights})
+            except NoTextNodeError:
+                # No text node (empty)?  Deal with it later in validation.
+                pass
+
+    def map_spec_type(self):
+        """Map sourceResource.genre
+
+        See map_format() and _genre_strings()
+        """
+        genre = iterify(self.provider_data.get('genre', []))
+        if genre:
+            spec_types = [g for g in _genre_strings(genre)
+                          if g.lower() in valid_spec_types]
+            if spec_types:
+                self.update_source_resource({'specType': spec_types})
+
+    def map_subject(self):
+        """Map sourceResource.subject
+
+        In feed XML:
+            //record/metadata/mods/subject/topic
+            or
+            //record/metadata/mods/subject/theme
+        In mapper request JSON:
+        {
+            "subject": [
+                {"topic": "Missouri--St. Louis"},
+                ...
+            ]
+        }
+        or
+        {
+            "subject": [
+                {
+                    "recordInfo": { ... },
+                    "theme": {
+                        "#text": "Bureau of Labor Statistics Publications",
+                        "xmlns:default": "http://www.loc.gov/mods/v3"
+                    }
+                }
+                ...
+            ]
+        }
+        """
+        def subject_strings(els):
+            """Yield all subject strings from given list of elements"""
+            for el in els:
+                try:
+                    s = None
+                    if 'topic' in el:
+                        s = textnode(el['topic'])
+                    elif 'theme' in el:
+                        s = textnode(el['theme'])
+                    if s:
+                        for subj in s.split(';'):
+                            yield subj.strip()
+                except NoTextNodeError:
+                    pass
+        subject = iterify(self.provider_data.get('subject', []))
+        if subject:
+            subjects = [s for s in subject_strings(subject)]
+            if subjects:
+                self.update_source_resource({'subject': subjects})
+
+    def map_spatial(self):
+        """Map sourceResource.spatial
+
+        See map_subject().
+        The JSON is formatted as follows:
+        {
+            "subject": [
+                {
+                    "hierarchicalGeographic": {
+                        "country": "United States",
+                        "state": "MO",
+                        "continent": "North America",
+                        "city": "St. Louis"
+                    },
+                    "cartographics": {
+                        "coordinates": "38.6277,-90.1995"
+                    }
+                }
+            ]
+        }
+        """
+        def coordinates(el):
+            """Return the coordinates string from the given dict"""
+            try:
+                return textnode(el.get('coordinates'))
+            except:
+                return ''
+        subjects = iterify(self.provider_data.get('subject', []))
+        if subjects:
+            ok_spatial = set(['city', 'county', 'state', 'country',
+                              'coordinates'])
+            spatial = []
+            # This logic of append() calls comes from oai_mods_mapper.
+            # The assignment of coordinate strings as their own list elements
+            # is by design.
+            # For the treatment of 'continent', see
+            # https://github.com/dpla/ingestion/pull/37
+            for s in subjects:
+                for hg in iterify(s.get('hierarchicalGeographic', [])):
+                    keys = set.intersection(ok_spatial, hg.keys())
+                    clean_hg = dict([(k, hg[k]) for k in keys])
+                    # 'continent' is not allowed in MAP v3.1 but it can be used
+                    # for spatial.name.
+                    if 'continent' in hg and len(hg) == 1:
+                        clean_hg['name'] = hg['continent']
+                    if clean_hg and clean_hg not in spatial:
+                        spatial.append(clean_hg)
+                for carto in iterify(s.get('cartographics', [])):
+                    c = coordinates(carto)
+                    if c and c not in spatial:
+                        spatial.append(c)
+            if spatial:
+                self.update_source_resource({'spatial': spatial})
+
+    def map_temporal(self):
+        """Map sourceResource.temporal
+
+        See map_subject() and map_spatial()
+        """
+        def temporal_strings(els):
+            for el in els:
+                try:
+                    yield textnode(el.get('temporal'))
+                except:
+                    pass
+        subjects = iterify(self.provider_data.get('subject', []))
+        temporal = [t for t in temporal_strings(subjects)]
+        if temporal:
+            self.update_source_resource({'temporal': temporal})
+
+    def location_url(self, attr_name, attr_value):
+        """URL for a //location/url with the given attribute
+
+        Exceptions: Could pass KeyError, IndexError, or TypeError, all
+                    indicating an expected attribute or text node was not
+                    found.
+        """
+        def first_url_string(location):
+            url_el = location.get('url')
+            urls = url_el if type(url_el) == list else [url_el]
+            for u in urls:
+                try:
+                    if attr_name in u and u[attr_name] == attr_value:
+                        return u['#text']
+                except (TypeError, KeyError):
+                    # Not a dict, or no text node
+                    pass
+        location = iterify(self.provider_data.get('location', []))
+        if location:
+            url_strings = (first_url_string(loc) for loc in location)
+            defined_url_strings = [s for s in url_strings if s]
+            if defined_url_strings:
+                return defined_url_strings[0]
+
+    def map_is_shown_at(self):
+        """Map isShownAt
+
+        In feed XML:
+            //record/metadata/mods/location/url[@access='object in context']
+        In body of mapper request JSON:
+            See the test, test_map_is_shown_at() in test_missouri_mapper.py
+            We can encounter multiple data structures.
+        """
+        is_shown_at = self.location_url('access', 'object in context')
+        if is_shown_at:
+            self.mapped_data['isShownAt'] = is_shown_at
+
+    def map_object(self):
+        """Map object
+
+        In feed XML:
+            //record/metadata/mods/location/url[@access='preview']
+        In body of mapper request JSON:
+            {
+              "location": {
+                "url": [
+                  {
+                    "#text": "http://digital.wustl.edu/example.gif",
+                    "access": "preview"
+                  }
+                ]
+              }
+            }
+        """
+        obj = self.location_url('access', 'preview')
+        if obj:
+            self.mapped_data['object'] = obj
+
+    def map_has_view(self):
+        """Map hasView
+
+        See location_url() and map_is_shown_at().
+        Use //record/metadata/mods/location/url[@access='object in context']
+        for hasView.@id.
+        Use //record/metadata/mods/physicalDescription/internetMediaType
+        for hasView.format.
+        """
+        def first_media_type(phys_descs):
+            """First internetMediaType string from physicalDescription list"""
+            for pd in phys_descs:
+                imt = pd.get('internetMediaType')
+                if imt:
+                    try:
+                        return textnode(imt)
+                    except NoTextNodeError:
+                        pass
+            return None
+        try:
+            if not 'hasView' in self.mapped_data:
+                self.mapped_data['hasView'] = {}
+            self.mapped_data['hasView'].update({
+                '@id': self.location_url('access', 'object in context')
+                })
+            phys_desc = iterify(self.provider_data.get('physicalDescription',
+                                                       []))
+            if phys_desc:
+                media_type = first_media_type(phys_desc)
+                if media_type:
+                    self.mapped_data['hasView'].update({'format': media_type})
+        except (KeyError, IndexError, TypeError):
+            # Not required
+            pass
+
+    def map_type(self):
+        """Map sourceResource.type
+
+        In feed XML:
+            //record/metadata/mods/typeOfResource
+        In body of mapper request JSON:
+            {
+                "typeOfResource": {
+                    "#text": "the type",
+                    "xmlns:default": "http://www.loc.gov/mods/v3"
+                }
+            }
+        """
+        # missing from MDH and WUSTL collections
+        def type_strings(els):
+            for el in els:
+                try:
+                    yield textnode(el)
+                except NoTextNodeError:
+                    pass
+        tor = iterify(self.provider_data.get('typeOfResource', []))
+        if tor:
+            types = [t for t in type_strings(tor)]
+            self.update_source_resource({'type': types})
+
+    def map_title(self):
+        """Map sourceResource.title
+
+        In feed XML:
+            //record/metadata/mods/titleInfo/title
+        In body of mapper request JSON:
+            {
+                'titleInfo': [
+                    {'title': 'the title'}
+                    ...
+                ]
+            }
+        ... where titleInfo could also be a dict with key 'title'
+        """
+        ti = iterify(self.provider_data.get('titleInfo', []))
+        if ti:
+            self.update_source_resource({'title': [textnode(t['title'])
+                                                   for t in ti]})
+
+
+def _genre_strings(els):
+    """Yield genre strings from list of elements"""
+    for el in els:
+        try:
+            yield textnode(el).strip()
+        except NoTextNodeError:
+            pass
+

--- a/lib/mappers/oai_mods_mapper.py
+++ b/lib/mappers/oai_mods_mapper.py
@@ -95,6 +95,9 @@ class OAIMODSMapper(Mapper):
                 if "hierarchicalGeographic" in s:
                     for h in iterify(s["hierarchicalGeographic"]):
                         if isinstance(h, dict):
+                            # TODO:  use set logic and declarative style, as
+                            # in MissouriMapper, instead of deleting list
+                            # elements
                             for k in h.keys():
                                 if k not in ["city", "county", "state",
                                              "country", "coordinates"]:

--- a/lib/spectype.py
+++ b/lib/spectype.py
@@ -1,0 +1,5 @@
+
+
+valid_spec_types = ['film/video', 'manuscript', 'maps', 'music',
+                    'musical score', 'newspapers', 'nonmusic',
+                    'photograph/pictorial works', 'serial', 'books']

--- a/lib/textnode.py
+++ b/lib/textnode.py
@@ -1,0 +1,23 @@
+"""
+Extract character data (text) nodes from xmltodict-style dictionaries
+"""
+
+
+__all__ = ['NoTextNodeError', 'textnode']
+
+
+class NoTextNodeError(Exception):
+    """Thrown when no character data node can be found"""
+    pass
+
+
+def textnode(d):
+    try:
+        if isinstance(d, basestring) and d:
+            return d
+        elif isinstance(d, dict) and d['#text']:
+            return d['#text']
+        else:
+            raise NoTextNodeError()
+    except KeyError:
+        raise NoTextNodeError()

--- a/profiles/missouri.pjs
+++ b/profiles/missouri.pjs
@@ -1,0 +1,42 @@
+{
+    "name": "missouri",
+    "type": "oai_verbs",
+    "metadata_prefix": "mohub_mods",
+    "endpoint_url": "http://data.mohistory.org:8081/repox/OAIHandler",
+    "blacklist": [],
+    "contributor": {
+        "@id": "http://dp.la/api/contributor/missouri-hub",
+        "name": "Missouri Hub"
+    },
+    "enrichments_coll": [
+        "/set_context",
+        "/validate_mapv3"
+    ],
+    "enrichments_item": [
+        "/select-id?prop=id",
+        "/dpla_mapper?mapper_type=missouri",
+        "/strip_html",
+        "/set_context",
+        "/cleanup_value",
+        "/capitalize_value",
+        "/dedup_value?prop=sourceResource%2Fcreator%2CsourceResource%2Fpublisher%2CsourceResource%2Fsubject%2CsourceResource%2Frelation",
+        "/enrich_earliest_date",
+        "/enrich-subject",
+        "/enrich_date",
+        "/enrich-type",
+        "/enrich-format",
+        "/enrich_location",
+        "/geocode",
+        "/enrich_language",
+        "/set_prop?prop=provider%2Fname&value=Missouri%20Hub",
+        "/set_prop?prop=sourceResource%2FstateLocatedIn&value=Missouri",
+        "/enrich_location?prop=sourceResource%2FstateLocatedIn",
+        "/copy_prop?prop=provider%2Fname&to_prop=dataProvider&skip_if_exists=True",
+        "/validate_mapv3"
+    ],
+    "thresholds": {
+        "added": 5000,
+        "changed": 1000,
+        "deleted": 1000
+    }
+}

--- a/test/server_support.py
+++ b/test/server_support.py
@@ -127,6 +127,8 @@ MODULES = [
     "dplaingestion.mappers.getty_mapper",
     "dplaingestion.akamod.dpla_mapper",
     "dplaingestion.akamod.set_context",
+    "dplaingestion.mappers.primo_mapper",
+    "dplaingestion.mappers.missouri_mapper",
     "dplaingestion.akamod.enrich",
     "dplaingestion.akamod.enrich-subject",
     "dplaingestion.akamod.enrich-type",

--- a/test/test_missouri_mapper.py
+++ b/test/test_missouri_mapper.py
@@ -1,0 +1,758 @@
+from nose.tools import assert_equals
+from dplaingestion.mappers.missouri_mapper import MissouriMapper
+
+empty_result = {'sourceResource': {}}
+
+def test_map_data_provider():
+    """MissouriMapper gets dataProvider from note"""
+    # Normal case
+    provider_data = {
+        'note': [
+            u'Here is the description ...',
+            {
+                u'#text': u'Washington University in St. Louis',
+                u'type': u'ownership'
+            }
+        ]
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_data_provider()
+    expected = {
+        'sourceResource': {},
+        'dataProvider': u'Washington University in St. Louis'
+    }
+    assert_equals(expected, mm.mapped_data)
+    # Empty ownership note:
+    #     <note>Description here...</note>
+    #     <note type="ownership"></note>
+    provider_data = {
+        'note': [
+                 u'Description here...',
+                 {u'type': 'ownership'}
+        ]
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_data_provider()
+    assert_equals(empty_result, mm.mapped_data)
+
+def test_map_creator():
+    """MissouriMapper gets sourceResource.creator from name"""
+    # Normal case
+    provider_data = {
+        'name': {
+            'namePart': 'John Kern', 
+            'role': {
+                'roleTerm': {'type': 'text', '#text': 'creator'}
+            }
+        }
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_creator()
+    assert_equals({'sourceResource': {'creator': ['John Kern']}},
+                  mm.mapped_data)
+    # Theoretical case of no role element
+    provider_data = {
+        'name': {
+            'namePart': 'John Kern'
+        }
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_creator()
+    assert_equals(empty_result, mm.mapped_data)
+    # Theoretical case of other role
+    provider_data = {
+        'name': {
+            'namePart': 'John Kern',
+            'role': {
+                'roleTerm': {'type': 'text', '#text': 'something else'}
+            }
+        }
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_creator()
+    assert_equals(empty_result, mm.mapped_data)
+    # Multiple creators
+    provider_data = {
+        'name': [
+            {
+                'namePart': 'Creator One',
+                'role': {
+                    'roleTerm': {'type': 'text', '#text': 'creator'}
+                }
+            },
+            {
+                'namePart': 'Creator Two',
+                'role': {
+                    'roleTerm': {'type': 'text', '#text': 'creator'}
+                }
+            }
+        ]
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_creator()
+    expected = {'sourceResource': {'creator': ['Creator One', 'Creator Two']}}
+    assert_equals(expected, mm.mapped_data)
+
+def test_map_date():
+    """MissouriMapper gets date from originInfo"""
+    # Normal cases
+    provider_data = {
+        'originInfo': [
+            {
+                'publisher': {'#text': 'Some Publisher'}
+            },
+            {
+                'dateOther': {'#text': '1963-09-22'}
+            }
+        ]
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_date()
+    assert_equals({'sourceResource': {'date': '1963-09-22'}}, mm.mapped_data)
+    provider_data = {
+        'originInfo': [
+            {
+                'publisher': {'#text': 'Some Publisher'}
+            },
+            {
+                'dateCreated': {'keyDate': 'yes', '#text': '1963-09-22'}
+            }
+        ]
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_date()
+    assert_equals({'sourceResource': {'date': '1963-09-22'}}, mm.mapped_data)
+    provider_data = {
+        'originInfo': [
+            {
+                'publisher': {'#text': 'Some Publisher'}
+            },
+            {
+                'dateIssued': {'point': 'start', '#text': '1963-09-22'}
+            }
+        ]
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_date()
+    assert_equals({'sourceResource': {'date': '1963-09-22'}}, mm.mapped_data)
+    # Empty element w/out text node?
+    provider_data = {
+        'originInfo': [
+            {
+                'publisher': {'#text': 'Some Publisher'}
+            },
+            {
+                'dateIssued': {'point': 'start'}
+            }
+        ]
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_date()
+    assert_equals({'sourceResource': {}}, mm.mapped_data)
+    # there is a list of a possible date element
+    provider_data = {
+        'originInfo': {
+            'dateCreated': [
+                {
+                    'point': 'end',
+                    '#text': '1904-12-31',
+                    'encoding': 'iso8601'
+                },
+                {
+                    'point': 'start',
+                    'keyDate': 'yes',
+                    '#text': '1904-01-01',
+                    'encoding': 'iso8601'
+                }
+            ]
+        }
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_date()
+    assert_equals({'sourceResource': {'date': '1904-01-01'}}, mm.mapped_data)
+    # sortDate is the only field available
+    provider_data = {'originInfo': {'sortDate': '2013-05-03'}}
+    mm = MissouriMapper(provider_data)
+    mm.map_date()
+    assert_equals({'sourceResource': {'date': '2013-05-03'}}, mm.mapped_data)
+
+def test_map_description():
+    """MissouriMapper gets description from first note string"""
+    provider_data = {
+        'note': [
+            'Here is the description.',
+            {
+              '#text': 'Washington University in St. Louis',
+              'type': 'ownership'
+            }
+        ]
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_description()
+    expected = {
+        'sourceResource': {
+            'description': ['Here is the description.']
+        }
+    }
+    assert_equals(expected, mm.mapped_data)
+    provider_data = {
+        'note': [
+            {
+                '#text': 'Washington University in St. Louis',
+                'type': 'ownership'
+            },
+            {
+                '#text': 'The description.',
+                'type': 'content'
+            },
+            'Secondary description.'
+        ]
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_description()
+    expected = {
+        'sourceResource': {
+            'description': ['The description.', 'Secondary description.']
+        }
+    }
+    assert_equals(expected, mm.mapped_data)
+
+def test_map_extent():
+    """MissouriMapper gets extent from physicalDescription"""
+    # Normal case
+    provider_data = {
+        'physicalDescription': {
+            'extent': '285 pages',
+            'xmlns:default': 'http://www.loc.gov/mods/v3'
+        }
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_extent()
+    assert_equals({'sourceResource': {'extent': '285 pages'}}, mm.mapped_data)
+    # physicalDescription could have no 'extent' property.  Real example:
+    # "physicalDescription": {
+    #     "xmlns:default": "http://www.loc.gov/mods/v3"
+    # }
+    provider_data = {
+        'physicalDescription': {
+            'xmlns:default': 'http://www.loc.gov/mods/v3'
+        }
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_extent()
+    assert_equals({'sourceResource': {}}, mm.mapped_data)
+
+def test_map_format():
+    """MissouriMapper gets format from physicalDescription or genre"""
+    provider_data = {
+        'genre': {
+            '#text': 'book',
+            'xmlns:default': 'http://www.loc.gov/mods/v3'
+        }
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_format()
+    assert_equals({'sourceResource': {'format': ['book']}}, mm.mapped_data)
+    provider_data = {
+        'physicalDescription': {
+            'note': 'book'
+        }
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_format()
+    assert_equals({'sourceResource': {'format': ['book']}}, mm.mapped_data)
+    # Not sure if something like this will ever be the case ...
+    provider_data = {
+        'physicalDescription': [
+            {'note': 'book'},
+            {'note': 'scrapbook'}
+        ]
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_format()
+    expected = {'sourceResource': {'format': ['book', 'scrapbook']}}
+    assert_equals(expected, mm.mapped_data)
+
+def test_map_is_shown_at():
+    """MissouriMapper gets isShownAt from location url for object in context"""
+    provider_data = {
+        'location': {
+            'url': [
+                {
+                    '#text': 'http://digital.wustl.edu/example',
+                    'access': 'object in context'
+                },
+                {
+                    '#text': 'http://digital.wustl.edu/example.gif',
+                    'access': 'preview'
+                },
+                'Bogus value to test robustness',
+                {
+                    '#text': 'another hypothetical test',
+                    'something': 'test'
+                }
+            ]
+        }
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_is_shown_at()
+    expected = {
+        'sourceResource': {},
+        'isShownAt': 'http://digital.wustl.edu/example'
+    }
+    assert_equals(expected, mm.mapped_data)
+    provider_data = {
+        'location': [
+            {
+                'xmlns:default': 'http://www.loc.gov/mods/v3',
+                'url': 'http://fraser.stlouisfed.org/publication/?pid=1272'
+            },
+            {
+                'url': {
+                    '#text': 'http://fraser.stlouisfed.org/example',
+                    'access': 'object in context'
+                }
+            }
+        ]
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_is_shown_at()
+    expected = {
+        'sourceResource': {},
+        'isShownAt': 'http://fraser.stlouisfed.org/example'
+    }
+    assert_equals(expected, mm.mapped_data)
+
+def test_map_object():
+    """MissouriMapper gets object from location url for preview"""
+    provider_data = {
+        'location': {
+            'url': [
+                {
+                    '#text': 'http://digital.wustl.edu/example',
+                    'access': 'object in context'
+                },
+                {
+                    '#text': 'http://digital.wustl.edu/example.gif',
+                    'access': 'preview'
+                },
+                'Bogus value to test robustness',
+                {
+                    '#text': 'another hypothetical test',
+                    'something': 'test'
+                }
+            ]
+        }
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_object()
+    expected = {
+        'sourceResource': {},
+        'object': 'http://digital.wustl.edu/example.gif'
+    }
+    assert_equals(expected, mm.mapped_data)
+
+
+def test_map_rights():
+    """MissouriMapper gets rights from accessCondition"""
+    provider_data = {'accessCondition': 'Copyright msg'}
+    mm = MissouriMapper(provider_data)
+    mm.map_rights()
+    assert mm.mapped_data == {'sourceResource': {'rights': ['Copyright msg']}}
+    provider_data =  {
+        'accessCondition': [
+            'http://digital.wustl.edu/',
+            'data are freely accessible'
+        ]
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_rights()
+    expected = {
+        'sourceResource': {
+            'rights': [
+                'http://digital.wustl.edu/',
+                'data are freely accessible'
+            ]
+        }
+    }
+    assert_equals(expected, mm.mapped_data)
+
+def test_map_type():
+    """MissouriMapper gets type from typeOfResource"""
+    provider_data = {'typeOfResource': {'#text': 'the type'}}
+    mm = MissouriMapper(provider_data)
+    mm.map_type()
+    assert_equals({'sourceResource': {'type': ['the type']}}, mm.mapped_data)
+
+def test_map_language():
+    """MissouriMapper gets language from language or languageTerm"""
+    provider_data = {
+        'language': {
+            '#text': 'eng',
+            'xmlns:default': 'http://some/namespace'
+        }
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_language()
+    assert_equals({'sourceResource': {'language': ['eng']}}, mm.mapped_data)
+    provider_data = {
+        'language': {
+            'languageTerm': {
+                '#text': 'jpn',
+                'type': 'code'
+            }
+        }
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_language()
+    assert_equals({'sourceResource': {'language': ['jpn']}}, mm.mapped_data)
+    provider_data = {
+        'language': {
+            'languageTerm': {
+                '#text': 'jpn; eng',
+                'type': 'text'
+            }
+        }
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_language()
+    assert_equals({'sourceResource': {'language': ['jpn', 'eng']}},
+                  mm.mapped_data)
+
+def test_map_identifier():
+    """MissouriMapper maps identifier"""
+    provider_data = {
+        'identifier': [
+          {
+            '#text': '11504366',
+            'type': 'oclc',
+            'xmlns:default': 'http://www.loc.gov/mods/v3'
+          },
+          {
+            '#text': ' 27303118',
+            'type': 'oclc',
+            'xmlns:default': 'http://www.loc.gov/mods/v3'
+          }
+        ]
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_identifier()
+    expected = {
+        'sourceResource': {
+            'identifier': ['OCLC:11504366', 'OCLC:27303118']
+        }
+    }
+    assert_equals(expected, mm.mapped_data)
+    provider_data = {'identifier': '1234'}
+    mm = MissouriMapper(provider_data)
+    mm.map_identifier()
+    assert_equals({'sourceResource': {'identifier': ['1234']}}, mm.mapped_data)
+
+def test_map_publisher():
+    """MissourMapper gets publisher from originInfo"""
+    provider_data = {
+        'originInfo': [
+          {'publisher': 'Publisher One'},
+          {'publisher': 'Publisher Two'},
+          {'someOtherField': '...'}
+        ]
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_publisher()
+    expected = {
+        'sourceResource': {
+            'publisher': ['Publisher One', 'Publisher Two']
+        }
+    }
+    assert_equals(expected, mm.mapped_data)
+    provider_data = {
+        "originInfo": {
+            "publisher": "Hong Kong: Longmen shudian,"
+        }
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_publisher()
+    expected = {
+        'sourceResource': {
+            'publisher': ['Hong Kong: Longmen shudian']
+        }
+    }
+    assert_equals(expected, mm.mapped_data)
+    provider_data = {
+        'originInfo': {
+            'publisher': '\n\n \n\n'
+        }
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_publisher()
+    expected = {'sourceResource': {}}
+    assert_equals(expected, mm.mapped_data)
+    # Hypothetical:
+    provider_data = {
+        'originInfo': {
+            'publisher': {'#text': 'The Publisher', 'someattr': 'abc'}
+        }
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_publisher()
+    expected = {
+        'sourceResource': {
+            'publisher': ['The Publisher']
+        }
+    }
+    assert_equals(expected, mm.mapped_data)
+
+def test_map_spec_type():
+    """MissouriMapper gets specType from genre"""
+    # A valid value is captured
+    provider_data = {
+        'genre': {
+            '#text': 'Photograph/Pictorial Works',
+            'authority': 'dct'
+        }
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_spec_type()
+    expected = {
+        'sourceResource': {
+            'specType': ['Photograph/Pictorial Works']
+        }
+    }
+    assert_equals(expected, mm.mapped_data)
+    # An invalid value is filtered out
+    provider_data = {
+        'genre': {
+            '#text': 'image',
+            'authority': 'dct'
+        }
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_spec_type()
+    assert_equals(empty_result, mm.mapped_data)
+
+def test_map_relation():
+    """MissouriMapper gets relation from relatedItem list"""
+    provider_data = {
+        'relatedItem': [
+            {
+                'location': {'url': 'http://fraser.stlouisfed.org/example/'},
+                'titleInfo': {'title': 'Title One'}
+            },
+            {
+                'titleInfo': {'title': 'Title Two\n'}
+            }
+        ]
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_relation()
+    expected = {
+        'sourceResource': {
+            'relation': [
+                'http://fraser.stlouisfed.org/example/',
+                'Title One',
+                'Title Two'
+            ]
+        }
+    }
+    assert_equals(expected, mm.mapped_data)
+
+def test_map_subject():
+    """MissouriMapper maps subject"""
+    provider_data = {
+        "subject": [
+            {"topic": "Missouri--St. Louis"},
+            {"topic": "Data and Statistical Publications"},
+            {"topic": "Subject One; Subject Two"},
+            {
+                "recordInfo": {
+                    "recordIdentifier": "42",
+                    "xmlns:default": "http://www.loc.gov/mods/v3"
+                },
+                "theme": {
+                    "#text": "Bureau of Labor Statistics Publications",
+                    "xmlns:default": "http://www.loc.gov/mods/v3"
+                }
+            },
+        ]
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_subject()
+    expected = {
+        'sourceResource': {
+            'subject': [
+                'Missouri--St. Louis',
+                'Data and Statistical Publications',
+                'Subject One',
+                'Subject Two',
+                'Bureau of Labor Statistics Publications'
+            ]
+        }
+    }
+    assert_equals(expected, mm.mapped_data)
+
+def test_map_has_view():
+    provider_data = {
+        'physicalDescription': {
+            'internetMediaType': 'image/JPEG2000'
+        },
+        'location': {
+            'url': [
+                {
+                    '#text': 'http://digital.wustl.edu/example',
+                    'access': 'object in context'
+                }
+            ]
+        }
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_has_view()
+    expected = {
+        'sourceResource': {},
+        'hasView': {
+            '@id': 'http://digital.wustl.edu/example',
+            'format': 'image/JPEG2000'
+        }
+    }
+    assert_equals(expected, mm.mapped_data)
+    provider_data = {
+        'physicalDescription': [
+            {'something': 'Whatever it is'},
+            {'internetMediaType': 'image/JPEG2000'}
+        ],
+        'location': {
+            'url': [
+                {
+                    '#text': 'http://digital.wustl.edu/example',
+                    'access': 'object in context'
+                }
+            ]
+        }
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_has_view()
+    expected = {
+        'sourceResource': {},
+        'hasView': {
+            '@id': 'http://digital.wustl.edu/example',
+            'format': 'image/JPEG2000'
+        }
+    }
+    assert_equals(expected, mm.mapped_data)
+
+def test_map_title():
+    """MissouriMapper deals with one or many title elements"""
+    provider_data = {
+        'titleInfo': [
+            {
+                'title': 'One'
+            },
+            {
+                'title': 'Two'
+            },
+            {
+                'title': 'Three'
+            }
+        ]
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_title()
+    expected = {'sourceResource': {'title': ['One', 'Two', 'Three']}}
+    assert_equals(expected, mm.mapped_data)
+    provider_data = {'titleInfo': {'title': 'The title'}}
+    mm = MissouriMapper(provider_data)
+    mm.map_title()
+    expected = {'sourceResource': {'title': ['The title']}}
+    assert_equals(expected, mm.mapped_data)
+
+def test_map_spatial():
+    """MissouriMapper assigns spatial from //subject/hierarchicalGeographic"""
+    provider_data = {
+        'subject': [
+            {
+                'topic': {
+                    'xmlns:php': 'http://php.net/xsl',
+                    '#text': 'St. Louis Street Scenes'
+                }
+            },
+            {
+                'hierarchicalGeographic': {
+                    'country': 'United States',
+                    'state': 'MO',
+                    'continent': 'North America'
+                },
+                'cartographics': {
+                    'coordinates': '38.2589,-92.4366'
+                }
+            },
+            {
+                'hierarchicalGeographic': {
+                    'country': 'United States',
+                    'state': 'MO',
+                    'continent': 'North America',
+                    'city': 'St Louis'
+                },
+                'cartographics': {
+                    'coordinates': '38.6277,-90.1995'
+                }
+            },
+            {
+                'hierarchicalGeographic': {
+                    'continent': 'North America'
+                }
+            }
+        ]
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_spatial()
+    expected = {
+        'sourceResource': {
+            'spatial': [
+                {
+                    'country': 'United States',
+                    'state': 'MO',
+                },
+                '38.2589,-92.4366',
+                {
+                    'country': 'United States',
+                    'state': 'MO',
+                    'city': 'St Louis'
+                },
+                '38.6277,-90.1995',
+                {
+                    'name': 'North America'
+                }
+            ]
+        }
+    }
+    assert_equals(expected, mm.mapped_data)
+
+def test_map_temporal():
+    """MissouriMapper assigns temporal from subject"""
+    provider_data = {
+        'subject': [
+            {
+                'topic': {
+                    'xmlns:php': 'http://php.net/xsl',
+                    '#text': 'Non-temporal element'
+                }
+            },
+            {
+                'temporal': {
+                    'xmlns:php': 'http://php.net/xsl',
+                    '#text': '2014'
+                }
+            },
+            {
+                'temporal': 'Early 21st Century'
+            }
+
+        ]
+    }
+    mm = MissouriMapper(provider_data)
+    mm.map_temporal()
+    expected = {
+        'sourceResource': {
+            'temporal': ['2014', 'Early 21st Century']
+        }
+    }
+    assert_equals(expected, mm.mapped_data)

--- a/test/test_oai_mods_mapper.py
+++ b/test/test_oai_mods_mapper.py
@@ -1,0 +1,19 @@
+from nose.tools import assert_equals
+from dplaingestion.mappers.oai_mods_mapper import OAIMODSMapper
+
+
+def test_map_subject_spatial_and_temporal():
+    provider_data = {
+        'subject': {
+            'temporal': '1901-1910'
+        }
+    }
+    m = OAIMODSMapper(provider_data)
+    m.map_subject_spatial_and_temporal()
+    expected = {
+        'sourceResource': {
+            'subject': [''],
+            'temporal': ['1901-1910']
+        }
+    }
+    assert_equals(expected, m.mapped_data)


### PR DESCRIPTION
- Add MissouriMapper and related tests
- Add lib/textnode.py
- Add `spectype' module with list of valid types.

Notes:
- Subject strings are split on semicolons in
  MissouriMapper.map_subject().  Splitting is done with the `shred'
  pipeline module in some other profiles.
- MissouriMapper overrides the title mapping performed in
  OAIMODSMapper.
  See https://issues.dp.la/issues/7617#note-19, item 4.
  OAIModsMapper was designed to treat various attributes not relevant
  to Missouri and appears designed to take the last title element it
  encounters.
- Titles and descriptions are assigned as lists.
- As with OAIMODSMapper's treatment of spatial data, we filter out
  hierarchicalGeographic properties that are not in the allowed list.
  We do, however, allow `continent', unlike in OAIMODSMapper.
