### PR TITLE
Add configuration item for httplib2 caches - DO NOT MERGE YET

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Configure an akara.ini file appropriately for your environment;
     Port=<port for Akara to run on>
     ; Recommended LogLevel is one of DEBUG or INFO
     LogLevel=<priority>
+    ; Default directory to cache certain HTTP requests
+    Httplib2CacheDir=/tmp
 
     [Bing]
     ApiKey=<your Bing Maps API key>

--- a/akara.conf.template
+++ b/akara.conf.template
@@ -224,6 +224,21 @@ class lookup:
         'scdl_fix_format': 'SCDL_FIX_FORMAT'
     }
 
+class httplib2_cacheable:
+    # Httplib2CacheDir: directory used for any Httplib2-specific caches
+    # NOTE: This must be explicitly passed to any modules or functions
+    # that call Httplib2
+    CACHE_DIR = "${Akara__Httplib2CacheDir}"
+
+class listrecords(httplib2_cacheable):
+    pass
+
+class listsets(httplib2_cacheable):
+    pass
+
+class oaisetname(httplib2_cacheable):
+    pass
+
 class identify_object:
     IGNORE = 0
     PENDING = 1
@@ -240,7 +255,7 @@ class artstor_identify_object(identify_object):
 class georgia_identify_object(identify_object):
     pass
 
-class nypl_identify_object(identify_object):
+class nypl_identify_object(identify_object, httplib2_cacheable):
     pass
 
 class ia_identify_object(identify_object):

--- a/lib/akamod/dpla-list-records.py
+++ b/lib/akamod/dpla-list-records.py
@@ -41,7 +41,7 @@ from datetime import datetime
 
 from dplaingestion.oai import oaiservice, OAIError, OAIHTTPError, OAIParseError
 
-
+CACHE_DIR = module_config().get('CACHE_DIR')
 LISTRECORDS_SERVICE_ID = 'http://purl.org/la.dp/dpla-list-records'
 
 @simple_service('GET', LISTRECORDS_SERVICE_ID, 'dpla-list-records', 'application/json')
@@ -57,7 +57,7 @@ def listrecords(endpoint, oaiset=None, resumption_token=None,
     if frm is not None and until is None:
         until = datetime.now().strftime("%Y-%m-%d")
 
-    remote = oaiservice(endpoint, logger)
+    remote = oaiservice(endpoint, logger, CACHE_DIR)
 
     try:
         list_records_result = \

--- a/lib/akamod/dpla-list-sets.py
+++ b/lib/akamod/dpla-list-sets.py
@@ -39,6 +39,7 @@ from akara import module_config
 
 from dplaingestion.oai import oaiservice
 
+CACHE_DIR = module_config().get('CACHE_DIR')
 LISTSETS_SERVICE_ID = 'http://purl.org/la.dp/dpla-list-sets'
 
 @simple_service('GET', LISTSETS_SERVICE_ID, 'oai.listsets.json', 'application/json')
@@ -48,6 +49,6 @@ def listsets(endpoint, limit=None):
 
     curl "http://localhost:8880/oai.listsets.json?limit=10"
     """
-    remote = oaiservice(endpoint, logger)
+    remote = oaiservice(endpoint, logger, CACHE_DIR)
     sets = remote.list_sets()[:int(limit)] if limit else remote.list_sets()
     return json.dumps(sets, indent=4)

--- a/lib/akamod/nypl_coll_title.py
+++ b/lib/akamod/nypl_coll_title.py
@@ -1,14 +1,15 @@
 """
-NYPL specific module for setting title for given collection;
+NYPL specific module for setting title for given collection
 """
-
-__author__ = 'aleksey'
 
 from akara import logger
 from akara import response
+from akara import module_config
 from akara.services import simple_service
 from amara.thirdparty import json, httplib2
 import xmltodict
+
+CACHE_DIR = module_config().get('CACHE_DIR')
 
 @simple_service('POST', 'http://purl.org/la/dp/nypl-coll-title',
                 'nypl-coll-title', 'application/json')
@@ -21,7 +22,7 @@ def nypl_identify_object(body, ctype, list_sets=None):
         response.add_header('content-type', 'text/plain')
         return "Unable to parse body as JSON"
 
-    H = httplib2.Http('/tmp/.cache')
+    H = httplib2.Http(CACHE_DIR)
     H.force_exception_as_status_code = True
     resp, content = H.request(list_sets)
     if not resp[u'status'].startswith('2'):

--- a/lib/akamod/oai-set-name.py
+++ b/lib/akamod/oai-set-name.py
@@ -2,8 +2,11 @@ import sys
 from akara.services import simple_service
 from akara import request, response
 from akara import logger
+from akara import module_config
 from amara.lib.iri import is_absolute
 from amara.thirdparty import json, httplib2
+
+CACHE_DIR = module_config().get('CACHE_DIR')
 
 @simple_service('POST', 'http://purl.org/la/dp/oai-set-name', 'oai-set-name', 'application/json')
 def oaisetname(body,ctype,sets_service=None):
@@ -31,7 +34,7 @@ def oaisetname(body,ctype,sets_service=None):
         prefix += request.environ['HTTP_HOST'] if request.environ.get('HTTP_HOST') else request.environ['SERVER_NAME']
         sets_service = prefix + sets_service
         
-    H = httplib2.Http('/tmp/.cache')
+    H = httplib2.Http(CACHE_DIR)
     H.force_exception_as_status_code = True
     resp, content = H.request(sets_service)
     if not resp[u'status'].startswith('2'):

--- a/lib/oai.py
+++ b/lib/oai.py
@@ -15,7 +15,7 @@ from dplaingestion.utilities import iterify
 import xmltodict
 from dplaingestion.selector import getprop
 
-XML_PARSE = lambda doc: xmltodict.parse(doc,xml_attribs=True,attr_prefix='',force_cdata=False,ignore_whitespace_cdata=True)
+XML_PARSE = lambda doc: xmltodict.parse(doc, xml_attribs=True, attr_prefix='', force_cdata=False, ignore_whitespace_cdata=True)
 
 PREFIXES = {
     u'o': u'http://www.openarchives.org/OAI/2.0/',

--- a/test/server_support.py
+++ b/test/server_support.py
@@ -208,6 +208,21 @@ class lookup:
         'scdl_fix_format': 'SCDL_FIX_FORMAT'
     }
 
+class httplib2_cacheable:
+    # Httplib2CacheDir: directory used for any Httplib2-specific caches
+    # NOTE: This must be explicitly passed to any modules or functions
+    # that call Httplib2
+    CACHE_DIR = "/tmp/testcache"
+
+class listrecords(httplib2_cacheable):
+    pass
+
+class listsets(httplib2_cacheable):
+    pass
+
+class oaisetname(httplib2_cacheable):
+    pass
+
 class identify_object:
     IGNORE = 0
     PENDING = 1
@@ -224,14 +239,18 @@ class artstor_identify_object(identify_object):
 class georgia_identify_object(identify_object):
     pass
 
-class nypl_identify_object(identify_object):
+class nypl_identify_object(identify_object, httplib2_cacheable):
     pass
 
 class ia_identify_object(identify_object):
     pass
 
+class david_rumsey_identify_object(identify_object):
+    pass
+
 class hathi_identify_object(identify_object):
     pass
+
 
 class type_conversion:
     # Map of "format" or "physical description" substring to


### PR DESCRIPTION
Some of the requests were failing on prod in ingestion since /tmp was not
writeable. This sets up a new configuration key, Akara.Httplib2CacheDir, which
can be used to specify a target directory for caches.