### PR TITLE
Fix source of NYPL rights

### DIFF
--- a/lib/fetchers/nypl_fetcher.py
+++ b/lib/fetchers/nypl_fetcher.py
@@ -84,7 +84,8 @@ class NYPLFetcher(AbsoluteURLFetcher):
                 record["tmp_image_id"] = item.get("imageID")
                 record["tmp_item_link"] = item.get("itemLink")
                 record["tmp_high_res_link"] = item.get("highResLink")
-                record["tmp_rights_statement"] = item.get("rightsStatement")
+                record["tmp_rights_statement"] = \
+                        getprop(content, "response/rightsStatement")
                 records.append(record)
 
             if error is not None:


### PR DESCRIPTION
Correct the element from which NYPL's rights statements are taken.

See https://issues.dp.la/issues/7845

This does what Mark Matienzo (@anarchivist) suggests in that ticket.  It takes the rights statement from the `response` element in the MODS endpoint's response.