### PR TITLE
Add usc no contributor check

### DIFF
--- a/lib/akamod/set_prop.py
+++ b/lib/akamod/set_prop.py
@@ -81,7 +81,8 @@ def unset_prop(body, ctype, prop=None, condition=None, condition_prop=None):
         "mwdl_exclude": lambda v: (v[0] == "collections" or
                                    v[0] == "findingAids"),
         "hathi_exclude": lambda v: "Minnesota Digital Library" in v,
-        "finding_aid_title": lambda v: v[0].startswith("Finding Aid")
+        "finding_aid_title": lambda v: v[0].startswith("Finding Aid"),
+        "usc_no_contributor": lambda v: not v[0].get("contributor", False)
     }
 
     def condition_met(condition_prop, condition):

--- a/profiles/usc.pjs
+++ b/profiles/usc.pjs
@@ -75,6 +75,7 @@
         "/dedup_value?prop=sourceResource%2Ftype",
         "/unset_prop?prop=sourceResource%2Fcollection",
         "/copy_prop?prop=provider%2Fname&to_prop=dataProvider&skip_if_exists=True",
+        "/unset_prop?prop=_id&condition=usc_no_contributor&condition_prop=sourceResource",
         "/validate_mapv3"
     ],
     "thresholds": {

--- a/test/test_set_prop.py
+++ b/test/test_set_prop.py
@@ -372,6 +372,62 @@ def test_unset_prop8():
     assert resp.status == 200
     assert json.loads(content) == INPUT
 
+def test_unset_prop9():
+    """
+    usc_no_contributor unsets property when sourceResource has no contributor
+    """
+    action = "unset"
+    prop = "_id"
+    condition = "usc_no_contributor"
+    condition_prop = "sourceResource"
+
+    INPUT = {
+        "_id": "1",
+        "sourceResource": {
+            "a": "aaa"
+        }
+    }
+    EXPECTED = {
+        "sourceResource": {
+            "a": "aaa"
+        }
+    }
+
+    resp, content = _get_server_response(json.dumps(INPUT), action=action,
+        prop=prop, condition=condition, condition_prop=condition_prop)
+    assert resp.status == 200
+    assert json.loads(content) == EXPECTED
+
+def test_unset_prop10():
+    """
+    usc_no_contributor unsets property when sourceResource has various empty
+    values for the contributor contributor
+    """
+    action = "unset"
+    prop = "_id"
+    condition = "usc_no_contributor"
+    condition_prop = "sourceResource"
+
+    for val in ["", None, []]:
+        INPUT = {
+            "_id": "1",
+            "sourceResource": {
+                "a": "aaa",
+                "contributor": val
+            }
+        }
+        EXPECTED = {
+            "sourceResource": {
+                "a": "aaa",
+                "contributor": val
+            }
+        }
+
+        resp, content = _get_server_response(json.dumps(INPUT), action=action,
+            prop=prop, condition=condition, condition_prop=condition_prop)
+        assert resp.status == 200
+        assert json.loads(content) == EXPECTED
+
 def test_unset_prop_finding_aid():
     """Should unset _id since title starts with 'Finding Aid'"""
     action = "unset"


### PR DESCRIPTION
Filter out USC records that have no `sourceResource.contributor`.

Addresses https://issues.dp.la/issues/7882
