### PR TITLE
Remove unset_prop step from USC profile (refs #8082, #7882)

### DIFF
--- a/profiles/usc.pjs
+++ b/profiles/usc.pjs
@@ -75,7 +75,6 @@
         "/dedup_value?prop=sourceResource%2Ftype",
         "/unset_prop?prop=sourceResource%2Fcollection",
         "/copy_prop?prop=provider%2Fname&to_prop=dataProvider&skip_if_exists=True",
-        "/unset_prop?prop=_id&condition=usc_no_contributor&condition_prop=sourceResource",
         "/validate_mapv3"
     ],
     "thresholds": {


### PR DESCRIPTION
The ingest we just ran removed too many records; per @guegueng's request, we need to reingest without this step.