### PR TITLE
Update Missouri and MWDL profiles

### DIFF
--- a/profiles/missouri.pjs
+++ b/profiles/missouri.pjs
@@ -1,8 +1,8 @@
 {
     "name": "missouri",
     "type": "oai_verbs",
-    "metadata_prefix": "mohub_mods",
-    "endpoint_url": "http://data.mohistory.org:8081/repox/OAIHandler",
+    "metadata_prefix": "mods",
+    "endpoint_url": "http://data.mohistory.org/services/mohub-cache/oai2.php",
     "blacklist": [],
     "contributor": {
         "@id": "http://dp.la/api/contributor/missouri-hub",

--- a/profiles/mwdl.pjs
+++ b/profiles/mwdl.pjs
@@ -4,7 +4,7 @@
     "endpoint_url": "http://utah-primoprod.hosted.exlibrisgroup.com/PrimoWebServices/xservice/search/brief",
     "endpoint_url_params": {
         "indx": 1,
-        "bulkSize": 500,
+        "bulkSize": 100,
         "institution": "MWDL",
         "loc": "local,scope:(mw)",
         "query": "facet_tlevel,exact,online_resources",


### PR DESCRIPTION
Updates to use relocate Missouri PMH endpoint and makes MWDL batch size smaller to address timeouts