### PR TITLE
Update the metadata prefix for Indiana

### DIFF
--- a/lib/oai.py
+++ b/lib/oai.py
@@ -264,7 +264,7 @@ class oaiservice(object):
         mapping, but silently ignore fields that are not.
         """
         map_key = prefix.lower()
-        if map_key == "oai_qdc":
+        if map_key in ["oai_qdc", "oai_qdc_imdpla"]:
             map_key = "qdc"
         mfm = metadata_field_map.get(map_key)
         hfm = header_field_map.get(map_key)

--- a/profiles/indiana.pjs
+++ b/profiles/indiana.pjs
@@ -2,7 +2,7 @@
     "name": "indiana", 
     "type": "oai_verbs",
     "endpoint_url": "http://dpla.library.in.gov/OAIHandler",
-    "metadata_prefix": "oai_qdc",
+    "metadata_prefix": "oai_qdc_imdpla",
     "contributor": {
         "@id": "http://dp.la/api/contributor/indiana",
         "name": "Indiana Memory"


### PR DESCRIPTION
Include the IN metadata prefix (oai_qdc_imdpla) in the qdc metadata field map.