### PR TITLE
Get hard-coded sets from BPL profile... 

### DIFF
--- a/lib/oai.py
+++ b/lib/oai.py
@@ -116,40 +116,68 @@ class oaiservice(object):
         return
     
     def list_sets(self):
-        #e.g. http://dspace.mit.edu/oai/request?verb=ListSets
-        qstr = urllib.urlencode({'verb' : 'ListSets'})
-        url = self.root + '?' + qstr
-        self.logger.debug('OAI request URL: {0}'.format(url))
-        start_t = time.time()
-        try:
-            content = urllib2.urlopen(url).read()
-        except urllib2.URLError as e:
-            raise OAIHTTPError("list_sets could not make request: %s" % \
-                               e.reason)
-        except urllib2.HTTPError as e:
-            raise OAIHTTPError("list_sets got status %d: %s" % \
-                               (e.code, e.reason))
-        retrieved_t = time.time()
-        self.logger.debug('Retrieved in {0}s'.format(retrieved_t - start_t))
+
         sets = []
+        resumptionToken = ''
+        #e.g. http://dspace.mit.edu/oai/request?verb=ListSets
+        params = {'verb' : 'ListSets'}
 
-        paths = [
-            u'string(o:setDescription/oai_dc:dc/dc:description)',
-            u'string(o:setDescription/o:oclcdc/dc:description)',
-            u'string(o:setDescription/dc:description)',
-            u'string(o:setDescription)'
-        ]
-        def receive_nodes(n):
-            setSpec = n.xml_select(u'string(o:setSpec)', prefixes=PREFIXES)
-            setName = n.xml_select(u'string(o:setName)', prefixes=PREFIXES)
-            #TODO better solution is to traverse setDescription amara tree
-            for p in paths:
-                setDescription = n.xml_select(p, prefixes=PREFIXES)
-                if setDescription:
-                    break
-            sets.append(dict([('setSpec', setSpec), ('setName', setName), ('setDescription', setDescription)]))
+        while True:
 
-        pushtree(content, u"o:OAI-PMH/o:ListSets/o:set", receive_nodes, namespaces=PREFIXES)
+            if resumptionToken:
+                params['resumptionToken'] = resumptionToken
+
+            qstr = urllib.urlencode(params)
+
+            url = self.root + '?' + qstr
+            self.logger.debug('OAI request URL: {0}'.format(url))
+            start_t = time.time()
+            try:
+                content = urllib2.urlopen(url).read()
+            except urllib2.URLError as e:
+                raise OAIHTTPError("list_sets could not make request: %s" % \
+                                   e.reason)
+            except urllib2.HTTPError as e:
+                raise OAIHTTPError("list_sets got status %d: %s" % \
+                                   (e.code, e.reason))
+            retrieved_t = time.time()
+            self.logger.debug('Retrieved in {0}s'.format(retrieved_t - start_t))
+
+            paths = [
+                u'string(o:setDescription/oai_dc:dc/dc:description)',
+                u'string(o:setDescription/o:oclcdc/dc:description)',
+                u'string(o:setDescription/dc:description)',
+                u'string(o:setDescription)'
+            ]
+            def receive_nodes(n):
+                setSpec = n.xml_select(u'string(o:setSpec)', prefixes=PREFIXES)
+                setName = n.xml_select(u'string(o:setName)', prefixes=PREFIXES)
+                #TODO better solution is to traverse setDescription amara tree
+                for p in paths:
+                    setDescription = n.xml_select(p, prefixes=PREFIXES)
+                    if setDescription:
+                        break
+                sets.append(dict([('setSpec', setSpec), ('setName', setName), ('setDescription', setDescription)]))
+
+            pushtree(content, u"o:OAI-PMH/o:ListSets/o:set", receive_nodes, namespaces=PREFIXES)
+            try:
+                xml_content = XML_PARSE(content)
+
+                resumptionToken = \
+                    xml_content["OAI-PMH"]["ListSets"].get("resumptionToken","")
+            except KeyError:
+                try:
+                    error = xml_content["OAI-PMH"]["error"]
+                    raise OAIError(error)
+                except KeyError:
+                    raise OAIParseError("Could not parse %s:\n%s" % (url, xml_content))
+            if isinstance(resumptionToken, dict):
+                resumptionToken = resumptionToken.get("#text", "")
+
+            # Apply resumptionToken to sets
+            if not resumptionToken:
+                break
+
         return sets
 
     def list_records(self, set_id=None, resumption_token="", metadataPrefix="",


### PR DESCRIPTION
…rather than getting them dynamically from OAI feed.

BPL has over 500 sets, which creates problems with during ingestion.  Before this PR, only the first 500 sets would be fetched from the OAI feed.  Any sets listed in the profile would be checked against those from the OAI feed; only those sets that were defined in both places were ingested.  This PR hard-codes BPL sets in the profile, and tweaks the OAI fetcher to (in the case of BPL) rely solely on these hard-coded set definitions to decide what is ingested.

I ran this locally and it seems to be working.  Here is the terminal output:

```python scripts/ingest_provider.py profiles/bpl.pjs
Creating ingestion document for profile profiles/bpl.pjs
Ingestion document da567ea8ce0a6776eb0dac53c81d06e4 created.
Fetching records for bpl
Can not determine fetcher threads, so using 1
Fetching records for set commonwealth:sn009x76k
Fetching records for set commonwealth-oai:n009wb72p
Fetching records for set commonwealth:mg74rv69r
[... all 738 sets are listed as being fetched ...]
Total items: 444656
Total collections: 0
Enqueuing: /var/folders/72/7z4p433s56v_3l4q7c4mvqc00000gn/T/tmpj3FIiA_bpl/0034ddeb-a7bc-4fdc-a006-d0ab10ecf260 (1 of 856)
Enqueuing: /var/folders/72/7z4p433s56v_3l4q7c4mvqc00000gn/T/tmpj3FIiA_bpl/0060ca2f-de3c-490b-8915-0361541a8e7c (2 of 856)
[... continues to run enqueings and save files without issue ... ]
```

I'm not sure if there's anything else I need to do to test that this is running correctly.  Please let me know.

This addresses [ticket #8651](https://issues.dp.la/issues/8651).