### PR TITLE
update scdl mapping

### DIFF
--- a/lib/mappers/scdl_mapper.py
+++ b/lib/mappers/scdl_mapper.py
@@ -18,9 +18,39 @@ class SCDLMapper(QDCMapper):
                 data_provider = data_provider[0]
             self.mapped_data.update({"dataProvider": data_provider})
 
+    def map_collection(self):
+        if exists(self.provider_data, "isPartOf"):
+            self.update_source_resource({"collection":
+                                         getprop(self.provider_data, 
+                                                 "isPartOf")})
+
     def map_relation(self):
         relation = []
         if "source" in self.provider_data:
                 relation.append(self.provider_data.get("source"))
         if relation:
             self.update_source_resource({"relation": relation})
+
+    def map_rights_and_accessrights(self):
+        rights_accessrights = []
+
+        if exists(self.provider_data, "rights"):
+            r = getprop(self.provider_data, "rights")
+            if isinstance(r, basestring):
+                r = [r]
+            rights_accessrights.append(r)
+
+        if exists(self.provider_data, "accessRights"):
+            a = getprop(self.provider_data, "accessRights")
+            if isinstance(a, basestring):
+                a = [a]
+            rights_accessrights.append(a)
+
+        # Remove NoneType elements and unnest rights_accessrights
+        rights_accessrights = filter(None, [i for sublist in rights_accessrights for i in sublist])
+
+        if rights_accessrights:
+            self.update_source_resource({"rights": rights_accessrights})
+
+    def map_multiple_fields(self):
+        self.map_rights_and_accessrights()


### PR DESCRIPTION
This updates the SCDL mapping.  It makes two changes:

1. Before, SCLD `rights` mapped to DPLA `rights`.  Now, both SCDL `rights` and `accessRights` map to DPLA `rights`.

2. Before SCDL `collection` mapped to DPLA `collection`.  Now, SCDL `isPartOf` maps to DPLA `collection`.

This has been tested locally with a small subset of documents.  I am currently running a local ingestion of all SCDL, but it will be several hours before it finishes.  Please do not merge until I can confirm that the full ingestion tested well.