### PR TITLE
handle multiple scdl collections

### DIFF
--- a/lib/mappers/scdl_mapper.py
+++ b/lib/mappers/scdl_mapper.py
@@ -21,13 +21,13 @@ class SCDLMapper(QDCMapper):
 
     def map_collection(self):
         """//dct:isPartOf -> sourceResource.collection"""
-        collection = None
+        if exists(self.provider_data, "isPartOf"):
+            collections = []
 
-        if exists(self.provider_data, 'isPartOf'):
-            for coll in iterify(getprop(self.provider_data, 'isPartOf')):
-                collection = {"collection": {"title": coll}}
-        if collection:
-            self.update_source_resource(collection)
+            for coll in iterify(getprop(self.provider_data, "isPartOf")):
+                collections.append({"title": coll})
+
+            self.update_source_resource({"collection": collections})
 
     def map_relation(self):
         relation = []


### PR DESCRIPTION
This allows the SCDL mapping to handle multiple collections.  When tested locally, 

`"isPartOf": "COLLECTION A"`
mapped to:
`"collection": ["COLLECTION A"]`

`"isPartOf": ["COLLECTION A", "COLLECTION B", "COLLECTION C"]`
mapped to:
`"collection": ["COLLECTION A", "COLLECTION B", "COLLECTION C"]`

This code is identical to the WI collection mapping (thanks, @moltude!).

This addresses [ticket DT-1129](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1129).