### PR TITLE
Revise geocoder to remove Bing lookups

### DIFF
--- a/lib/akamod/geocode.py
+++ b/lib/akamod/geocode.py
@@ -175,17 +175,9 @@ class DplaGeonamesGeocoder(object):
         place.set_name()
         params = {}
 
-        # Whether to register coordinates for a Place, which could be a region
-        # that is too large to warrent pinpointing with falsely-precise
-        # coordinates that would clutter a map interface that shows points for
-        # objects.
-        register_coordinates = True
-
-        # TODO: considering filtering on specific feature codes
         if place.name in [place.country, place.region]:
             params['featureClass'] = 'A'
-            register_coordinates = False
-        elif place.name == place.state:
+        elif place.name in [place.county, place.state]:
             params['featureClass'] = 'A'
             params['countryBias'] = 'US'
         elif place.name == place.city:
@@ -231,7 +223,7 @@ class DplaGeonamesGeocoder(object):
                 'feature_type': interp.get('fcode')
             })
 
-            if register_coordinates:
+            if candidate_place.name != candidate_place.country:
                 candidate_place.coordinates = "%s, %s" % (interp['lat'],
                                                           interp['lng'])
 
@@ -458,7 +450,7 @@ class Place:
         Returns a list of the fields to be included in DPLA MAP's
         serializations of Place.
         """
-        fields = ['name', 'city', 'state', 'country', 'region', 'county']
+        fields = ['name', 'city', 'state', 'county', 'country', 'region']
         if (not self.feature_type) or (not 'PCL' in self.feature_type):
             fields.append('coordinates')
         return fields

--- a/lib/akamod/geocode.py
+++ b/lib/akamod/geocode.py
@@ -168,10 +168,6 @@ class DplaGeonamesGeocoder(object):
         are already present, will attempt to validate them before accepting
         the new place.
         """
-        if place.name and re.search(ur" *(United States(?!-)|États-Unis|USA)",
-                                    place.name):
-            place.name = 'United States'
-
         place.set_name()
         params = {}
 
@@ -457,10 +453,20 @@ class Place:
 
     def set_name(self):
         """
-        Returns the name property. If none is set, sets it to the smallest
-        available geographic division label.
+        Modify and return our name property, after cleaning it up. If none is
+        set, initialize it to the smallest available geographic division label.
         """
         if self.name:
+            if re.search(ur" *(United States(?!-)|États-Unis|USA)", self.name):
+                self.name = 'United States'
+            # Kludge state abbreviations with periods (e.g. "S.C." or "CA.")
+            # into their equivalent official post-office abbreviations (e.g.
+            # "SC" or "CA"). GeoNames just doesn't resolve the ones with
+            # periods.  We can get rid of this when we switch to Twofishes.
+            self.name = re.sub(r'([ACDFGHIKLMNOPRSTUVW])\.?'
+                               r'([KLRZAOTEIDNSYCHJMVXV])\.',
+                               r'\1\2',
+                               self.name)
             return self.name
 
         prop_order = ["city", "county", "state", "country", "region"]

--- a/lib/akamod/geocode.py
+++ b/lib/akamod/geocode.py
@@ -168,6 +168,10 @@ class DplaGeonamesGeocoder(object):
         are already present, will attempt to validate them before accepting
         the new place.
         """
+        if place.name and re.search(ur" *(United States(?!-)|États-Unis|USA)",
+                                    place.name):
+            place.name = 'United States'
+
         place.set_name()
         params = {}
 

--- a/lib/akamod/geocode.py
+++ b/lib/akamod/geocode.py
@@ -355,7 +355,9 @@ class DplaGeonamesGeocoder(object):
     def _name_search(self, name, params={}):
         """Search GeoNames for a given name and return a dict of the result"""
         defaults = { "q": name.encode("utf8"),
-                     "maxRows": 15,
+                     "maxRows": 3,
+                     "isNameRequired": "true",
+                     "orderBy": "relevance",
                      "username": module_config().get("geonames_username"),
                      "token": module_config().get("geonames_token") }
         params = dict(defaults.items() + params.items())

--- a/test/test_geocode.py
+++ b/test/test_geocode.py
@@ -359,7 +359,7 @@ def test_geocode_set_name_county():
         "sourceResource": {
             "spatial": {
                 "county": "Los Angeles County",
-                "country": "Bananas"
+                "country": "United States"
             }
         }
     }
@@ -370,11 +370,10 @@ def test_geocode_set_name_county():
             "spatial": [
                 {
                     "county": "Los Angeles County",
-                    "country": "Bananas",
+                    "country": "United States",
                     "name": "Los Angeles County",
                     "state": "California",
-                    #uses bing because geonames wants to match country values
-                    "coordinates": "33.9934997559, -118.29750824"
+                    "coordinates": "34.19801, -118.26102"
                 }
             ]
         }
@@ -437,38 +436,6 @@ def test_geocode_set_name_state():
                 "country": "United States",
                 "state": "California",
                 "name": "California"
-            }]
-        }
-    }
-
-    url = server() + "geocode"
-    resp,content = H.request(url,"POST",body=json.dumps(INPUT))
-    assert resp.status == 200
-    assert_same_jsons(EXPECTED, json.loads(content))
-
-@attr(travis_exclude='yes')
-def test_geocode_set_name_by_feature():
-    """Should set the name property to the smallest available feature value"""
-    INPUT = {
-        "id": "12345",
-        "_id": "12345",
-        "sourceResource": {
-            "spatial": {
-                "country": "Canada",
-                "city": "Bananas"
-            }
-        }
-    }
-    EXPECTED = {
-        "id": "12345",
-        "_id": "12345",
-        "sourceResource": {
-            "spatial": [{
-                'coordinates': '62.8329086304, -95.9133224487',
-                'country': 'Canada',
-                'name': 'Bananas',
-                'state': 'Nunavut',
-                "city": "Bananas"
             }]
         }
     }
@@ -588,7 +555,6 @@ def test_geocode_geonames_name_search():
     resp, content = H.request(url, "POST", body=json.dumps(INPUT))
     assert resp.status == 200
     assert_same_jsons(EXPECTED, json.loads(content))
-
 
 @attr(travis_exclude='yes')
 def test_geocode_geonames_name_search_context():

--- a/test/test_geocode.py
+++ b/test/test_geocode.py
@@ -152,9 +152,8 @@ def test_collapse_hierarchy():
                   'country': 'United States',
                   'county': 'Los Angeles County',
                   'name': 'Los Angeles',
-                  'state': 'California'},
-                { 'country': 'United States',
-                  'name': 'United States'}
+                  'state': 'California'
+                }
             ]
         },
         "creator": "David"
@@ -673,7 +672,8 @@ def test_geocode_unicode():
         "_id": "12345",
         "sourceResource": {
             "spatial": [{
-                "name": u"États-Unis"
+                "country": "United States",
+                "name": "United States"
             }]
         }
     }

--- a/test/test_geocode.py
+++ b/test/test_geocode.py
@@ -6,7 +6,7 @@ from amara.thirdparty import json
 from nose.plugins.attrib import attr
 from dict_differ import assert_same_jsons
 from dplaingestion.selector import setprop, getprop, exists
-from dplaingestion.akamod.geocode import Place, floats_to_coordinates, get_coordinates
+from dplaingestion.akamod.geocode import Place, floats_to_coordinates, parse_coordinates_from_name
 
 @attr(travis_exclude='yes')
 def test_geocode():
@@ -498,7 +498,6 @@ def test_geocode_skip_united_states():
         for field in ["name", "country"]:
             setprop(INPUT, "sourceResource/spatial", {field: v})
             resp, content = H.request(url, "POST", body=json.dumps(INPUT))
-            # from nose.tools import set_trace; set_trace()
             assert resp.status == 200
             for place in json.loads(content)['sourceResource']['spatial']:
                 assert 'coordinates' not in place.keys()
@@ -697,10 +696,10 @@ def test_geocode_place_get_coodinates():
     """Should check for and build coordinates from string even when in reverse
     order
     """
-    assert get_coordinates('not coordinate') == None
-    assert get_coordinates('999.84, 123.33') == None
-    assert get_coordinates('33.33, 123.33') == '33.33, 123.33'
-    assert get_coordinates('123.33,33.33') == '33.33, 123.33'
+    assert parse_coordinates_from_name('not coordinate') == None
+    assert parse_coordinates_from_name('999.84, 123.33') == None
+    assert parse_coordinates_from_name('33.33, 123.33') == '33.33, 123.33'
+    assert parse_coordinates_from_name('123.33,33.33') == '33.33, 123.33'
 
 
 def test_geocode_floats_to_coodinates():


### PR DESCRIPTION
This feature branch started out as one for switching our `geocode` enrichment over to use Twofishes. I started out with the idea that I'd first remove Bing and then add Twofishes, but then, after removing Bing, we decided it would be best to get this merged into `develop` sooner and add Twofishes with a subsequent PR.

* Remove Bing lookups.
* Reduce the number of interpretations that must be considered for a given Place. (Reduce the number of GeoNames API requests.)
* Improve `geocoder` place name handling and tests. Simplify the way we reject place names that are just "United States" or its variants, and some other things. See the commit message.
* Change the way in which spatial objects are collapsed. Allow a list of places where one is "Los Angeles" and another is "Unites States" (or an equivalent) to
be rolled up into one Place, Los Angeles, which is in the United States. This actually makes good on a promise one of the tests purported to make, but did not fulfill entirely.
* Remove some redundancy in tests that assert that the most-specific feature name is used for the place name.

To check this PR, you will want to `python setup.py install` locally and `nosetests test/test_geocode.py`. You can try out `geocode` on your own data by running Postman with this collection that I have created: https://www.getpostman.com/collections/2442bf8be3089d1a659d
To use this collection, run akara locally with `akara -f akara.conf start`.
