### PR TITLE
Remove 'class geocoding' from akara config template

### DIFF
--- a/akara.conf.template
+++ b/akara.conf.template
@@ -205,11 +205,6 @@ MODULES = [
 
 ### Section 3: Other module configuration goes here
 
-class geocoding:
-    cache_max_age = 86400*7
-    geocoder = 'http://purl.org/com/zepheira/services/geocoders/local-geonames'
-    geonames_dbfile = Akara.ConfigRoot+'/caches/geonames.sqlite3'
-
 class geocode: 
     bing_api_key = "${Bing__ApiKey}"
     geonames_username = "${Geonames__Username}"


### PR DESCRIPTION
Here's a tiny little change to fix something that is a minor annoyance for someone trying to read and troubleshoot our code. Annoying because it can lead you off-track for a minute or so.

Remove obsolete 'class geocoding' section from akara.conf.template. I think that this was a leftover from many years ago when a Zephiera module was being used for the geocoder, before the `geocode` module was added. If you search `ingestion` for 'geocoding' you will find that this class is not used anywhere anymore.
