### PR TITLE
Fix IndexError exception in geocoder

### DIFF
--- a/lib/akamod/geocode.py
+++ b/lib/akamod/geocode.py
@@ -239,7 +239,7 @@ class TwofishesGeocoder():
         url = self._url(xtra_params)
         try:
             return self._twofishes_data(url)['interpretations'][0]
-        except KeyError as e:
+        except (KeyError, IndexError) as e:
             return {}
 
     def _url(self, params):

--- a/test/test_geocode.py
+++ b/test/test_geocode.py
@@ -565,7 +565,7 @@ def test_geocode_name_search_failure():
         "_id": "12345",
         "sourceResource": {
             "spatial": {
-                "name": "1234567"
+                "name": "Some Nonexistent Place"
             }
         }
     }
@@ -575,7 +575,7 @@ def test_geocode_name_search_failure():
         "_id": "12345",
         "sourceResource": {
             "spatial": [{
-                "name": "1234567"
+                "name": "Some Nonexistent Place"
             }]
         }
     }


### PR DESCRIPTION
When encountering a name that can't be resolved, geocoder has been not properly catching exceptions within `_geocode_place()` that result when the 'interpretations' property of the response is an empty list. This fixes that problem by adding IndexError to the list of exception classes that are caught.