### PR TITLE
Changes to Getty mapper

### DIFF
--- a/profiles/getty.pjs
+++ b/profiles/getty.pjs
@@ -31,6 +31,8 @@
         "/set_spec_type",
         "/enrich-type",
         "/enrich_language",
+        "/enrich_location",
+        "/geocode",
         "/set_type_from_physical_format",
         "/copy_prop?prop=provider%2Fname&to_prop=dataProvider&skip_if_exists=True"
     ],


### PR DESCRIPTION
From tickets https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1343 and https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1213

* Creator: add PrimoNMBib/record/display/lds50
* Description: remove PrimoNMBib/record/display/rights
* Spatial: addPrimoNMBib/record/display/coverage
* Rights: add PrimoNMBib/record/display/rights
* Subject: add PrimoNMBib/record/display/lds49
* isShownAt: when PrimoNMBib/record/display/sourceid = GETTY_ROSETTA
  replace the current mapping with PrimoNMBib/record/display/lds29.
  Leave the mapping for GETTY_OCP as is
* Add geo enrichments to Getty profile
* Explicitly unmap relation