### PR TITLE
Swap httplib library for request library in fetcher.py

### DIFF
--- a/lib/fetchers/fetcher.py
+++ b/lib/fetchers/fetcher.py
@@ -17,6 +17,7 @@ from dplaingestion.selector import setprop
 from dplaingestion.selector import getprop as get_prop
 from dplaingestion.utilities import iterify, couch_id_builder
 import requests
+import re
 
 
 def getprop(obj, path):


### PR DESCRIPTION
Rewrite of fetcher.request_content_from() to use the request library instead of httplib. The request library simplifies these requests and follows HTTP 301 redirects which httplib did not.