### PR TITLE
Rewrite Internet Archive fetcher

### DIFF
--- a/lib/fetchers/ia_fetcher.py
+++ b/lib/fetchers/ia_fetcher.py
@@ -1,355 +1,74 @@
-from dplaingestion.fetchers.absolute_url_fetcher import *
-from dplaingestion.utilities import with_retries
-from amara.thirdparty import json
-from collections import OrderedDict, Counter
-from xml.parsers import expat
-from abc import ABCMeta
-from multiprocessing.dummy import Pool
-from Queue import Full, Empty, Queue
-from threading import Lock
-import signal
-
-class IAFetcher(AbsoluteURLFetcher):
-    def __init__(self, profile, uri_base, config_file):
-        super(IAFetcher, self).__init__(profile, uri_base, config_file)
-        self.coll_record_count = 0
-        self.retry = []
-        self.get_file_url = profile.get("get_file_url")
-        self.prefix_files = profile.get("prefix_files")
-        self.prefix_meta = profile.get("prefix_meta")
-        self.prefix_dc = profile.get("prefix_dc")
-        self.shown_at_url = profile.get("shown_at_url")
-        self.fetch_pool = None
-        self.queue = Queue(maxsize=profile.get("endpoint_url_params")["rows"])
-        self.mutex = Lock()
-        self.docs_counter = Counter({"downloaded": 0})
-        self._initstophook()
-        self.task_args = (self.get_file_url, self.prefix_files,
-                          self.shown_at_url, self.fetch_url)
+import traceback
+import internetarchive
+from akara import logger
+from dplaingestion.fetchers.fetcher import Fetcher
 
 
-    def _stophandler(self, signum, frame):
-        print >> sys.stderr,"Got shutdown signal %d. Going to close pool." % \
-                            signum
-        print >> sys.stderr, "Sending notification to pool workers..."
-        for i in reversed(range(len(self.fetch_pool._pool))):
-            worker_process = self.fetch_pool._pool[i]
-            if worker_process.exitcode is None and hasattr(worker_process,
-                                                           "pid"):
-                print >> sys.stderr, "Sending %d signal to %d pid..." % \
-                                     (signal.SIGUSR1, worker_process.pid)
-                os.kill(worker_process.pid, signal.SIGUSR1)
-        self.fetch_pool.terminate()
-        print >> sys.stderr, "Work is terminated..."
-        self.fetch_pool.join()
-        sys.exit(signum)
+class IAFetcher(Fetcher):
 
-    def _initstophook(self):
-        signal.signal(signal.SIGINT, self._stophandler)
-        signal.signal(signal.SIGTERM, self._stophandler)
-        signal.signal(signal.SIGQUIT, self._stophandler)
+    def fetch_all_data(self, sets=None):
+        """A generator for all of the provider's item and collection records
 
-    def task_done(self, result):
-        with self.mutex:
-            if result.status == TaskResult.RETRY:
-                self.retry.append(result.result)
-
-            if result.error_message:
-                result.result = result.error_message
-
-            try:
-                self.queue.put(result.result, block=False)
-            except Full:
-                print >> sys.stderr, "Error, queue full."
-
-    def run_task(self, task, retry=False):
-        try:
-            task.run(retry)
-            return task.get_result()
-        except Exception as e:
-            return TaskResult(TaskResult.ERROR, None, task.__class__.__name__,
-                              "%s: %s" % (e.__class__.__name__, str(e)))
-
-    @with_retries(10, 1)
-    def fetch_url(self, url):
+        The interface for Fetcher.fetch_all_data() (Not as defined in Fetcher,
+        but in practice, the way it's invoked by fetch_records.py) has a
+        `set' argument. IAFetcher does not use this, and gets its collections
+        from its provider profile (ia.pjs). IAFetcher will raise an Exception
+        if `sets' is set.
         """
-        Downloads data related to the given url and checks that the response
-        code is 200.
+        if sets:
+            raise Exception("IAFetcher does not take a `sets' argument, but "
+                            "'%s' was provided." % sets)
+        self.create_collection_records()
+        self.reset_response()
+        for token in self.collections.iterkeys():
+            self.response['records'].append(self.collections[token])
+            i = 1
+            for item in internetarchive \
+                        .search_items("collection:%s" % token) \
+                        .iter_as_items():
+                try:
+                    md = item.item_metadata
+                    md['_id'] = "ia--%s" % md['metadata']['identifier']
+                    md['collection'] = self.source_resource_collection(token)
+                    self.response['records'].append(md)
+                    i += 1
+                    if i >= self.batch_size:
+                        # ^^^ Should probably use `==' but being paranoid about
+                        # possible but unlikely batch_size of 1.
+                        yield self.response
+                        self.reset_response()
+                        i = 1
+                except Exception as e:
+                    tb = traceback.format_exc(5)
+                    msg = "In IA collection %s: %s" % (token, e)
+                    self.response['errors'].append(msg)
+                    logger.error("%s\n%s" % (msg, tb))
+            if len(self.response['records']):
+                # last yield of the collection
+                yield self.response
+                self.reset_response()
+
+    def source_resource_collection(self, token):
+        """Return one collection dict suitable for sourceResource.collection
+
+        Args:
+            token: The collection token / identifier that's a key of the
+                profile's 'collections' object
+
+        Returns dict, which will be empty if there is no such collection.
+
+        FIXME: Refactor to move this function into Fetcher and clean up code in
+        other modules that have their own independent implementations of the
+        same logic.
+            - AbsoluteURLFetcher.fetch_all_data()
+              and AbsoluteURLFetcher.add_collection_to_item_records()
+            - OAIVerbsFetcher.fetch_all_data()
+              and OAIVerbsFetcher.add_collection_to_item_records()
+            - MDLAPIFetcher.add_collection_to_item_records()
+            - NARAFetcher.add_collection_to_item_records()
+            - PrimoFetcher.add_collection_to_item_records()
+            - EDANFetcher.add_collection_to_item_record()
         """
-        response = None
-        try:
-            response = urllib2.urlopen(url, timeout=10)
-            code = response.getcode()
-            assert code == 200, "Bad response code = " + str(code)
-            return response.read()
-        finally:
-            if response:
-                response.close()
-
-    def extract_xml_content(self, content, url):
-        error = None
-        try:
-            content = json.loads(content)
-        except Exception, e:
-            error = "Error parsing content from URL %s: %s" % (url, e)
-
-        return error, content
-
-    def retry_request_records(self):
-        def _batch_size_chunks(_list):
-            """
-            Yield successive batch sized chunks of _list.
-            """
-            for i in xrange(0, len(_list), self.batch_size):
-                yield _list[i:i+self.batch_size]
-
-        ids = [id for id in self.retry]
-        retry = False
-        self.record_coll_count = 0
-        error_count = 0
-
-        for chunk in _batch_size_chunks(ids):
-            self.fetch_pool = Pool(processes=10)
-            for id in chunk:
-                args = (FetchDocumentTask(id, *self.task_args), retry,)
-                self.fetch_pool.apply_async(self.run_task,
-                                            args=args,
-                                            callback=self.task_done)
-            self.fetch_pool.close()
-            self.fetch_pool.join()
-
-            errors = []
-            records = []
-            while not self.queue.empty():
-                record = self.queue.get(False)
-
-                if isinstance(record, basestring):
-                    errors.append(record)
-                    error_count += 1
-                else:
-                    records.append(record)
-                    self.coll_record_count += 1
-
-                if self.queue.empty() or \
-                   (len(records) > 0 and len(records) % self.batch_size == 0):
-                    print "Fetched %s of %s, %s errors" % \
-                          (self.coll_record_count, len(ids), error_count)
-
-                    yield errors, records
-                    errors = []
-                    records = []
-
-    def request_records(self, content, set_id=None):
-        content = content["response"]
-        total_records = int(content["numFound"])
-        read_records = int(content["start"])
-        expected_records = self.endpoint_url_params["rows"]
-        total_pages = total_records/expected_records + 1
-        request_more =  total_pages != self.endpoint_url_params["page"]
-
-        if not request_more:
-            # Since we are at the last page the expected_records will not
-            # be equal to self.endpoint_url_params["rows"]
-            expected_records = total_records - read_records
-            # Reset the page for the next collection
-            self.endpoint_url_params["page"] = 1
-        else:
-            self.endpoint_url_params["page"] += 1
-
-        ids = [doc["identifier"] for doc in content["docs"]]
-
-        self.fetch_pool = Pool(processes=10)
-        retry = True
-        for id in ids:
-            args = (FetchDocumentTask(id, *self.task_args), retry,)
-            self.fetch_pool.apply_async(self.run_task,
-                                        args=args,
-                                        callback=self.task_done)
-                                                    
-        self.fetch_pool.close()
-        self.fetch_pool.join()
-
-        errors = []
-        records = []
-        while not self.queue.empty():
-            record = self.queue.get(False)
-
-            if isinstance(record, basestring):
-                errors.append(record)
-            else:
-                if record["metadata"]["mediatype"] == "collection":
-                    continue
-                records.append(record)
-                self.coll_record_count += 1
-
-            if (self.queue.empty() or (len(records) > 0 and
-                                       len(records) % self.batch_size == 0)):
-                print "Fetched %s of %s, %s will be retried" % \
-                      (self.coll_record_count, total_records, len(self.retry))
-
-                yield errors, records, request_more
-                errors = []
-                records = []
-
-        if not request_more:
-            # Reset the collection record count
-            self.coll_record_count = 0
-
-    def retry_fetches(self):
-        for errors, records in self.retry_request_records():
-            yield errors, records
-
-class TaskResult(object):
-    SUCCESS = 0 # result is available, no error message
-    ERROR = 1   # result is unavailable, error message presents
-    RETRY = 2   # result is unavailable, error message presents, error is not
-                # critical and task should be restarted
-
-    def __init__(self, status, result, _type, error_message=None):
-        self.status = status
-        self.result = result
-        self.task_type = _type
-        self.error_message = error_message
-
-
-class IngestTask(object):
-    __metaclass__ = ABCMeta
-
-    def run(self):
-        pass
-
-    def get_result(self):
-        pass
-
-class FetchDocumentTask(IngestTask):
-    def __init__(self, identifier, file_url_pattern, prefix,
-                 shown_at_url, fetch_url):
-        self.identifier = identifier
-        self.file_url_pattern = file_url_pattern
-        self.prefix = prefix
-        self.shown_at_url = shown_at_url
-        self.fetch_url = fetch_url
-
-    def _get_parsed_xml(self, url):
-        try:
-            content = self.fetch_url(url)
-        except Exception, e:
-            raise Exception("Error (%s) fetching data from URL: %s" %
-                            (str(e), url))
-        try:
-            return self._parse(content)
-        except expat.ExpatError as e:
-            raise Exception("Error (%s) parsing data from URL: %s" %
-                            (str(e), url))
-
-    def _parse(self, content):
-        return xmltodict.parse(content,
-                               xml_attribs=True,
-                               attr_prefix='',
-                               force_cdata=False,
-                               ignore_whitespace_cdata=True)
-
-    def _skip_doc_message(self, url, error=None, error_level="ERROR"):
-        if isinstance(error, Exception):
-            error = "%s: %s" % (error.__class__.__name__, str(error))
-        msg = ("%s: Document with id \"%s\" " %
-               (error_level, self.identifier) +
-               "is skipped or malformed while working with url=\"%s\", " %
-               url + "caused by error: %s" % str(error))
-        return msg
-
-    def _retry_doc_message(self, url):
-        return "Document with id \"%s\" and url %s will be retried." % \
-               (self.identifier, url)
-
-    def run(self, retry):
-        id = self.identifier
-        prefix = self.prefix
-        shown_at_url = self.shown_at_url
-        files_url = self.file_url_pattern.format(id, prefix.format(id))
-        try:
-            files_response = self._get_parsed_xml(files_url)["files"]
-        except Exception, e:
-            if retry:
-                task_status = TaskResult.RETRY
-                msg = self._retry_doc_message(files_url)
-                result = id
-            else:
-                task_status = TaskResult.ERROR
-                msg = self._skip_doc_message(files_url, e)
-                result = None            
-
-            self._result = TaskResult(task_status,
-                                      result,
-                                      self.__class__.__name__,
-                                      msg)
-            return
-
-        item_data = {"dc": None, "meta": None, "gif": None, "pdf": None,
-                     "shown_at": shown_at_url.format(id),
-                     "marc": None}
-        for file_info in files_response["file"]:
-            _format = file_info["format"]
-            name = file_info["name"]
-            if _format == "Text PDF":
-                item_data["pdf"] = name
-            elif _format == "Animated GIF":
-                item_data["gif"] = name
-            elif _format == "Grayscale LuraTech PDF" and not item_data["pdf"]:
-                item_data["pdf"] = name
-            elif _format == "Metadata" and name.endswith("_meta.xml"):
-                item_data["meta"] = name
-            elif _format == "Dublin Core":
-                item_data["dc"] = name
-            elif _format == "MARC":
-                item_data["marc"] = name
-
-        assert item_data["meta"] is not None, ("document \"" + id +
-                                               "\" meta data is absent")
-
-        item = {"files": item_data,
-                "_id": id}
-        meta_url = self.file_url_pattern.format(id, item_data["meta"])
-        try:
-            item.update(self._get_parsed_xml(meta_url))
-        except Exception as e:
-            if retry:
-                task_status = TaskResult.RETRY
-                msg = self._retry_doc_message(meta_url)
-                result = id
-            else:
-                task_status = TaskResult.ERROR
-                msg = self._skip_doc_message(meta_url, e)
-                result = None
-
-            self._result = TaskResult(task_status,
-                                      result,
-                                      self.__class__.__name__,
-                                      msg)
-            return
-
-        if item_data["marc"]:
-            marc_url = self.file_url_pattern.format(id, item_data["marc"])
-            try:
-                item.update(self._get_parsed_xml(marc_url))
-            except Exception as e:
-                if retry:
-                    task_status = TaskResult.RETRY
-                    msg = self._retry_doc_message(marc_url)
-                    result = id
-                else:
-                    task_status = TaskResult.ERROR
-                    msg = self._skip_doc_message(marc_url, e)
-                    result = None
-
-                self._result = TaskResult(task_status,
-                                          result,
-                                          self.__class__.__name__,
-                                          msg)
-                return
-
-        self._result = TaskResult(TaskResult.SUCCESS, item,
-                                  self.__class__.__name__)
-
-    def get_result(self):
-        return self._result
+        exclusions = ('_id', 'ingestType')
+        return {k:v for k, v in self.collections.get(token, {}).items()
+                if k not in exclusions}

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ MarkupSafe==0.23
 pyrax
 avro
 mock
+internetarchive==1.5.0

--- a/test/test_fetcher.py
+++ b/test/test_fetcher.py
@@ -125,19 +125,6 @@ def test_absolute_url_fetcher_uva2():
         assert response["records"]
         break
 
-@nottest
-@attr(uses_network="yes", travis_exclude="yes")
-def test_absolute_url_fetcher_ia():
-    profile_path = "profiles/ia.pjs"
-    fetcher =  create_fetcher(profile_path, uri_base, config_file)
-    assert fetcher.__class__.__name__ == "IAFetcher"
-
-    fetcher.endpoint_url_params["rows"] = 10
-    for response in fetcher.fetch_all_data():
-        assert not response["errors"]
-        assert response["records"]
-        break
-
 # Exclude the MWDL test in Travis as access to the feed is restricted
 @attr(travis_exclude='yes', uses_network='yes')
 def test_absolute_url_fetcher_mwdl():

--- a/test/test_ia_fetcher.py
+++ b/test/test_ia_fetcher.py
@@ -1,0 +1,107 @@
+import json
+import internetarchive
+from nose import with_setup
+from nose.tools import assert_raises, assert_equals
+from mock import MagicMock
+from akara import logger
+from dplaingestion.fetchers.ia_fetcher import IAFetcher
+
+
+logger.error = MagicMock()  # Forego printing noise to `nosetests' output
+
+
+def setup():
+    global fetcher, item1, item2, item3
+
+    item1 = MagicMock()
+    item1.item_metadata = {'metadata': {'identifier': 'id1'}}
+    item2 = MagicMock()
+    item2.item_metadata = {'metadata': {'identifier': 'id2'}}
+    item3 = MagicMock()
+    item3.item_metadata = {'metadata': {'identifier': 'id3'}}
+
+    items_gen_col1 = (i for i in [item1])
+    items_gen_col2 = (i for i in [item2, item3])
+
+    # Search result objects from search_items()
+    search_col1 = MagicMock()
+    search_col1.iter_as_items = MagicMock(return_value=items_gen_col1)
+    search_col2 = MagicMock()
+    search_col2.iter_as_items = MagicMock(return_value=items_gen_col2)
+    search_for_col = {'collection:col1': search_col1,
+                      'collection:col2': search_col2}
+
+    def _search_items(s):
+        # See internetarchive.search_items() call in IAFetcher.fetch_all_data()
+        return search_for_col[s]
+
+    internetarchive.search_items = MagicMock(side_effect=_search_items)
+
+    uri_base = 'http://localhost:8080'
+    with open('profiles/ia.pjs', 'r') as profile_fh:
+        profile = json.load(profile_fh)
+    fetcher = IAFetcher(profile, uri_base, '/dev/null')
+    fetcher.collections = {'col1': {'title': 'Collection 1'},
+                           'col2': {'title': 'Collection 2'}}
+
+@with_setup(setup)
+def test_fail_sets_arg():
+    """Raises Exception if it receives a `sets' argument"""
+    with assert_raises(Exception) as ctxt_mgr:
+        fetcher.fetch_all_data(sets='x').next()
+    assert(str(ctxt_mgr.exception).startswith('IAFetcher does not take'))
+
+@with_setup(setup)
+def test_adds_underscore_id():
+    """Adds the `_id' field with the right formatting to item records"""
+    # Collection records get the _id added in
+    # Fetcher.create_collection_records() and are outside of the domain of this
+    # test.
+    for batch in fetcher.fetch_all_data():
+        for record in batch['records']:
+            if record.get('ingestType') != 'collection':
+                identifier = record['metadata']['identifier']
+                assert(record['_id'] == "ia--%s" % identifier)
+
+@with_setup(setup)
+def test_adds_collection_to_item():
+    """Adds a `collection' JSON object / Python dict to an item record"""
+    for batch in fetcher.fetch_all_data():
+        for record in batch['records']:
+            if record.get('ingestType') != 'collection':
+                assert(isinstance(record['collection'], dict))
+
+@with_setup(setup)
+def test_adds_error_to_response():
+    """Catches exception for record, adds it to `errors' array in response"""
+    # Trigger a KeyError for 'identifier'
+    item1.item_metadata = {'metadata': {}}
+    errors = []
+    for batch in fetcher.fetch_all_data():
+        errors.extend(batch['errors'])
+    assert_equals(len(errors), 1)
+    assert_equals(errors[0], "In IA collection col1: 'identifier'")
+
+@with_setup(setup)
+def test_adds_good_records_despite_error():
+    """Catches exception for record, adds other good records to response"""
+    # KeyError for 'identifier', as above, flunking out one of the records
+    item1.item_metadata = {'metadata': {}}
+    records = []
+    for batch in fetcher.fetch_all_data():
+        records.extend(batch['records'])
+    assert_equals(len(records), 4)  # 2 Collections plus 2 good items
+
+@with_setup(setup)
+def test_batch_sizes():
+    """Divides result into batches correctly based on `batch_size'"""
+    fetcher.batch_size = 2
+    total_records = 0
+    for batch in fetcher.fetch_all_data():
+        num_recs = len(batch['records'])
+        assert(num_recs <= fetcher.batch_size)
+        total_records += num_recs
+    assert_equals(total_records, 5)  # 2 collections plus 3 items
+
+if __name__ == "__main__":
+    raise SystemExit("Please run these tests with the `nosetests' command.")


### PR DESCRIPTION
See https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1391

This changeset rewrites the Internet Archive fetcher to use IA's `internetarchive` Python module.

A new test suite has been dedicated to the Internet Archive harvester.

You probably want to click "view" on the `ia_fetcher.py` diff and just read the new file.