### PR TITLE
Fix for `setprop` call for records with intermediate providers.

### DIFF
--- a/lib/mappers/pa_mapper.py
+++ b/lib/mappers/pa_mapper.py
@@ -114,7 +114,7 @@ class PAMapper(DublinCoreMapper):
         if exists(self.provider_data, prop):
             im_prov = getprop(self.provider_data, prop)
             if im_prov:
-                self.setprop(self.mapped_data, "intermediateProvider", im_prov)
+                setprop(self.mapped_data, "intermediateProvider", im_prov)
 
     def map_is_shown_at(self):
         """


### PR DESCRIPTION
Tested locally for an entire PA harvest. This fix restored tens of thousands of records from "Missing sourceResource."