### PR TITLE
Improve check-counts script to report more info

### DIFF
--- a/scripts/check_ingestion_counts.py
+++ b/scripts/check_ingestion_counts.py
@@ -9,11 +9,11 @@ Usage:
 import os
 import sys
 import argparse
+import traceback
 from akara import logger
 from datetime import datetime
 from amara.thirdparty import json
 from dplaingestion.couch import Couch
-from dplaingestion.selector import getprop
 import smtplib
 from email.mime.text import MIMEText
 from dateutil import parser as dateparser
@@ -29,80 +29,108 @@ def define_arguments():
 
     return parser
 
+def alerts(i_doc):
+    """Return a string for the alerts part of the email
+
+    i_doc: the dict-like object from Couch.dashboard_db for the ingestion doc.
+    """
+    alerts = []
+    count_type = ('Added', 'Changed', 'Deleted')
+    for ct in count_type:
+        count = int(i_doc['count' + ct])
+        threshold = int(i_doc['thresholds'][ct.lower()])
+        if count > threshold:
+            alerts.append("  * %d items %s exceeds threshold of %d."
+                          % (count, ct.lower(), threshold))
+    if alerts:
+        return "Alerts:\n%s" % "\n".join(alerts)
+    else:
+        return "There were no alerts."
+
+def statistics(i_doc):
+    """Return a string for the statistics part of the email
+
+    i_doc: the dict-like object from Couch.dashboard_db for the ingestion doc.
+    """
+    stats = []
+    stats.append("  * Records added: %d" % num(i_doc['countAdded']))
+    stats.append("  * Records changed: %d" % num(i_doc['countChanged']))
+    stats.append("  * Records deleted: %d" % num(i_doc['countDeleted']))
+    stats.append("  * Items fetched: %d"
+                 % num(i_doc['fetch_process']['total_items']))
+    stats.append("  * Items enriched: %d"
+                 % num(i_doc['enrich_process']['total_items']))
+    stats.append("  * Items saved: %d"
+                 % num(i_doc['save_process']['total_items']))
+    stats.append("  * Collections fetched: %s"
+                 % num(i_doc['fetch_process']['total_collections']))
+    stats.append("  * Collections enriched: %d"
+                 % num(i_doc['enrich_process']['total_collections']))
+    stats.append("  * Collections saved: %d"
+                 % num(i_doc['save_process']['total_collections']))
+    return "Statistics:\n%s" % "\n".join(stats)
+
+def num(n):
+    if n == None:
+        return 0
+    else:
+        return int(n)
+
 def main(argv):
     parser = define_arguments()
     args = parser.parse_args(argv[1:])
 
     couch = Couch()
-    ingestion_doc = couch.dashboard_db[args.ingestion_document_id]
-    if getprop(ingestion_doc, "delete_process/status") != "complete":
-        print "Error, delete process did not complete"
-        return -1
+    i_doc = couch.dashboard_db[args.ingestion_document_id]
+    if i_doc['delete_process']['status'] != 'complete':
+        print >> sys.stderr, 'Error: delete process did not complete'
+        return 1
 
-    # Update ingestion document
-    kwargs = {
-        "check_counts_process/status": "running",
-        "check_counts_process/start_time": iso_utc_with_tz()
-    }
+    # Update ingestion document to indicate that we're running
+    kwargs = {'check_counts_process/status': 'running',
+              'check_counts_process/start_time': iso_utc_with_tz()}
     try:
-        couch.update_ingestion_doc(ingestion_doc, **kwargs)
+        couch.update_ingestion_doc(i_doc, **kwargs)
     except:
-        print "Error updating ingestion document " + ingestion_doc["_id"]
-        return -1
-
-    # Check each count against the threshold
-    alerts = []
-    count_type = ("Added", "Changed", "Deleted")
-    for ctype in count_type:
-        count = int(ingestion_doc["count" + ctype])
-        threshold = int(ingestion_doc["thresholds"][ctype.lower()])
-        if count > threshold:
-            alerts.append("%s items %s exceeds threshold of %s" %
-                          (count, ctype.lower(), threshold))
+        tb = traceback.format_exc(5)
+        print "Error updating ingestion document %s\n%s" % (i_doc["_id"], tb)
+        return 1
 
     error_msg = None
-    if alerts:
-        config_file = "akara.ini"
+    try:
         config = ConfigParser.ConfigParser()                                    
-        config.readfp(open(config_file))
-        to = [s.strip() for s in config.get("Alert", "To").split(",")]
-        frm = config.get("Alert", "From")
-
-        month = dateparser.parse(ingestion_doc["ingestDate"]).strftime("%B")
-        alerts = "\n".join(alerts)
-        msg = MIMEText(alerts)
-        msg["Subject"] = "Threshold(s) exceeded for %s ingestion of %s" % \
-                         (month, ingestion_doc["provider"])
-        msg["To"] = ", ".join(to)
-        msg["From"] = frm
-
-        try:
-            s = smtplib.SMTP("localhost")
-            s.sendmail(frm, to, msg.as_string())
-            s.quit()
-        except Exception, e:
-            error_msg = e
-
-    if error_msg:
-        print >> sys.stderr, ("********************\n" +
-                              "Error sending alert email: %s" % error_msg)
-        print >> sys.stderr, ("Alerts:\n%s" % alerts +
-                              "\n********************")
+        config.readfp(open('akara.ini'))
+        to = [s.strip() for s in config.get('Alert', 'To').split(',')]
+        frm = config.get('Alert', 'From')
+        body = "%s\n\n%s" % (alerts(i_doc), statistics(i_doc))
+        msg = MIMEText(body)
+        msg['Subject'] = "%s ingest #%s" % (i_doc['provider'],
+                                            i_doc['ingestionSequence'])
+        msg['To'] = ', '.join(to)
+        msg['From'] = frm
+        s = smtplib.SMTP("localhost")
+        s.sendmail(frm, to, msg.as_string())
+        s.quit()
+    except Exception, e:
+        error_msg = e
+        tb = traceback.format_exc(5)
+        print >> sys.stderr, "Error sending alert email: %s\n%s" % (error_msg,
+                                                                    tb)
 
     # Update ingestion document
-    status = "complete"
-    kwargs = {
-        "check_counts_process/status": status,
-        "check_counts_process/error": error_msg,
-        "check_counts_process/end_time": iso_utc_with_tz()
-    }
+    kwargs = {'check_counts_process/status': 'complete',
+              'check_counts_process/error': error_msg,
+              'check_counts_process/end_time': iso_utc_with_tz()}
     try:
-        couch.update_ingestion_doc(ingestion_doc, **kwargs)
+        couch.update_ingestion_doc(i_doc, **kwargs)
     except:
-        print "Error updating ingestion document " + ingestion_doc["_id"]
-        return -1
+        tb = traceback.format_exc(5)
+        print >> sys.stderr, "Error updating ingestion document %s\n%s" \
+                             % (i_doc["_id"], tb)
+        return 1
 
-    return 0 if status == "complete" else -1
+    return 0
 
 if __name__ == '__main__':
-    main(sys.argv)
+    rv = main(sys.argv)
+    sys.exit(rv)


### PR DESCRIPTION
Change `check_ingestion_counts.py` per https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1404

Report various statistics that are available in the ingest dashboard document, which were not reported before.

Refactor various parts of the code that were not ideal.

This does not report on the total provider counts reported by BigCouch and Elasticsearch because:
* That would mean adding configuration and code for communication with Elasticsearch,
* The Couch views for total counts are QA views, and we wouldn't want to put those on a production server, because they use too much disk and take too long to generate.
* We can just check the frontend /partners page for the Elasticsearch count
* We don't want to spend too much time on `ingestion` when we are trying to keep our efforts focused on Ingestion 3.