### PR TITLE
Replace wildcard imports in fetchers with explicit ones

### DIFF
--- a/lib/fetchers/absolute_url_fetcher.py
+++ b/lib/fetchers/absolute_url_fetcher.py
@@ -1,5 +1,7 @@
-from dplaingestion.fetchers.fetcher import *
+import sys
 import threading
+from dplaingestion.utilities import iterify
+from dplaingestion.fetchers.fetcher import Fetcher
 
 
 class AbsoluteURLFetcher(Fetcher):

--- a/lib/fetchers/cdl_fetcher.py
+++ b/lib/fetchers/cdl_fetcher.py
@@ -1,4 +1,7 @@
-from dplaingestion.fetchers.absolute_url_fetcher import *
+from amara.thirdparty import json
+from dplaingestion.utilities import iterify
+from dplaingestion.fetchers.absolute_url_fetcher \
+    import AbsoluteURLFetcher, getprop
 
 
 class CDLFetcher(AbsoluteURLFetcher):

--- a/lib/fetchers/edan_fetcher.py
+++ b/lib/fetchers/edan_fetcher.py
@@ -1,4 +1,9 @@
-from dplaingestion.fetchers.file_fetcher import *
+import os
+import re
+import xmltodict
+from dplaingestion.utilities import iterify
+from dplaingestion.fetchers.file_fetcher import FileFetcher
+
 
 class EDANFetcher(FileFetcher):
     def __init__(self, profile, uri_base, config_file):

--- a/lib/fetchers/file_fetcher.py
+++ b/lib/fetchers/file_fetcher.py
@@ -1,5 +1,9 @@
-from dplaingestion.fetchers.fetcher import *
 import os
+import hashlib
+import fnmatch
+from dplaingestion.utilities import couch_id_builder
+from dplaingestion.fetchers.fetcher import Fetcher, XML_PARSE
+
 
 class FileFetcher(Fetcher):
     def __init__(self, profile, uri_base, config_file):

--- a/lib/fetchers/getty_fetcher.py
+++ b/lib/fetchers/getty_fetcher.py
@@ -1,4 +1,6 @@
-from dplaingestion.fetchers.primo_fetcher import *
+from dplaingestion.utilities import iterify
+from dplaingestion.fetchers.primo_fetcher import PrimoFetcher, getprop
+
 
 class GettyFetcher(PrimoFetcher):
     def __init__(self, profile, uri_base, config_file):

--- a/lib/fetchers/hathi_fetcher.py
+++ b/lib/fetchers/hathi_fetcher.py
@@ -1,4 +1,6 @@
-from dplaingestion.fetchers.file_fetcher import *
+import itertools as it
+from dplaingestion.fetchers.file_fetcher import FileFetcher
+
 
 class HathiFetcher(FileFetcher):
     def __init__(self, profile, uri_base, config_file):

--- a/lib/fetchers/mdl_api_fetcher.py
+++ b/lib/fetchers/mdl_api_fetcher.py
@@ -1,5 +1,9 @@
 import json
-from dplaingestion.fetchers.fetcher import *
+import hashlib
+from urllib import urlencode
+from dplaingestion.utilities import iterify, couch_id_builder
+from dplaingestion.fetchers.fetcher import Fetcher, getprop
+
 
 class MDLAPIFetcher(Fetcher):
     def __init__(self, profile, uri_base, config_file):

--- a/lib/fetchers/mwdl_fetcher.py
+++ b/lib/fetchers/mwdl_fetcher.py
@@ -1,4 +1,6 @@
-from dplaingestion.fetchers.primo_fetcher import *
+from dplaingestion.utilities import iterify
+from dplaingestion.fetchers.primo_fetcher import PrimoFetcher, getprop
+
 
 class MWDLFetcher(PrimoFetcher):
     def __init__(self, profile, uri_base, config_file):

--- a/lib/fetchers/nara_fetcher.py
+++ b/lib/fetchers/nara_fetcher.py
@@ -1,4 +1,7 @@
-from dplaingestion.fetchers.file_fetcher import *
+from dplaingestion.utilities import iterify
+from dplaingestion.fetchers.fetcher import getprop
+from dplaingestion.fetchers.file_fetcher import FileFetcher
+
 
 class NARAFetcher(FileFetcher):
     def __init__(self, profile, uri_base, config_file):

--- a/lib/fetchers/nypl_fetcher.py
+++ b/lib/fetchers/nypl_fetcher.py
@@ -1,4 +1,8 @@
-from dplaingestion.fetchers.absolute_url_fetcher import *
+from dplaingestion.selector import exists
+from dplaingestion.utilities import iterify
+from dplaingestion.fetchers.fetcher import getprop
+from dplaingestion.fetchers.absolute_url_fetcher import AbsoluteURLFetcher
+
 
 class NYPLFetcher(AbsoluteURLFetcher):
     def __init__(self, profile, uri_base, config_file):

--- a/lib/fetchers/oai_verbs_fetcher.py
+++ b/lib/fetchers/oai_verbs_fetcher.py
@@ -1,6 +1,7 @@
-from dplaingestion.fetchers.fetcher import *
 from amara.thirdparty import json
-from dplaingestion.utilities import *
+from dplaingestion.utilities import iterify
+from dplaingestion.fetchers.fetcher import Fetcher, getprop
+
 
 class OAIVerbsFetcher(Fetcher):
     def __init__(self, profile, uri_base, config_file):

--- a/lib/fetchers/primo_fetcher.py
+++ b/lib/fetchers/primo_fetcher.py
@@ -1,6 +1,9 @@
-from dplaingestion.fetchers.fetcher import *
-from urllib import urlencode
 import threading
+import hashlib
+from urllib import urlencode
+from dplaingestion.utilities import iterify, couch_id_builder
+from dplaingestion.fetchers.fetcher import Fetcher, getprop
+
 
 class PrimoFetcher(Fetcher):
     def __init__(self, profile, uri_base, config_file):

--- a/lib/fetchers/uva_fetcher.py
+++ b/lib/fetchers/uva_fetcher.py
@@ -1,4 +1,6 @@
-from dplaingestion.fetchers.absolute_url_fetcher import *
+from dplaingestion.utilities import iterify
+from dplaingestion.fetchers.absolute_url_fetcher import AbsoluteURLFetcher
+
 
 class UVAFetcher(AbsoluteURLFetcher):
     def __init__(self, profile, uri_base, config_file):


### PR DESCRIPTION
Replace cases of `import *` in fetcher modules with explicit imports for better clarity.
