### PR TITLE
Increase timeout in `internetarchive.search_items()`.

### DIFF
--- a/lib/fetchers/ia_fetcher.py
+++ b/lib/fetchers/ia_fetcher.py
@@ -24,7 +24,8 @@ class IAFetcher(Fetcher):
             self.response['records'].append(self.collections[token])
             i = 1
             for item in internetarchive \
-                        .search_items("collection:%s" % token) \
+                        .search_items("collection:%s" % token,
+                                request_kwargs=dict(timeout=60)) \
                         .iter_as_items():
                 try:
                     md = item.item_metadata


### PR DESCRIPTION
This should resolve the timeout issues you were running into with `internetarchive.search_items()`. I think 60 seconds should be more than enough, but feel free to bump that up some more if you continue to have issues.

Also, give me a heads up if that's not enough. I would think 60 seconds is enough time for any query. I'll take a closer look server side if you still have issues.