### PR TITLE
Increase IA fetcher HTTP timeout

### DIFF
--- a/lib/fetchers/ia_fetcher.py
+++ b/lib/fetchers/ia_fetcher.py
@@ -24,7 +24,8 @@ class IAFetcher(Fetcher):
             self.response['records'].append(self.collections[token])
             i = 1
             for item in internetarchive \
-                        .search_items("collection:%s" % token) \
+                        .search_items("collection:%s" % token,
+                                      request_kwargs={'timeout': 60}) \
                         .iter_as_items():
                 try:
                     md = item.item_metadata

--- a/test/test_ia_fetcher.py
+++ b/test/test_ia_fetcher.py
@@ -31,7 +31,7 @@ def setup():
     search_for_col = {'collection:col1': search_col1,
                       'collection:col2': search_col2}
 
-    def _search_items(s):
+    def _search_items(s, request_kwargs):
         # See internetarchive.search_items() call in IAFetcher.fetch_all_data()
         return search_for_col[s]
 


### PR DESCRIPTION
Increase the Internet Archive fetcher's HTTP timeout so that it doesn't fail when requests are slow to be served.

Thanks to @jjjake for https://github.com/dpla/ingestion/pull/131 !  This has been amended slightly from the change in that PR to make a necessary change to the fetcher's test suite.
