### PR TITLE
Add select-id-missouri service

### DIFF
--- a/akara.conf.template
+++ b/akara.conf.template
@@ -201,7 +201,8 @@ MODULES = [
     "dplaingestion.akamod.validate_mapv3",
     "dplaingestion.akamod.dpla_mapper",
     "dplaingestion.akamod.set_context",
-    "dplaingestion.akamod.strip_html"
+    "dplaingestion.akamod.strip_html",
+    "dplaingestion.akamod.select-id-missouri"
     ]
 
 ### Section 3: Other module configuration goes here

--- a/lib/akamod/select-id-missouri.py
+++ b/lib/akamod/select-id-missouri.py
@@ -11,11 +11,8 @@ from dplaingestion.utilities import couch_rec_id_builder, clean_id
 @simple_service('POST', 'http://purl.org/la/dp/select-id-missouri',
                 'select-id-missouri', 'application/json')
 def selid(body, ctype, prop='handle', use_source='yes'):
-    '''
-    Service that accepts a JSON document and adds or sets the "id" property to
-    the value of the property named by the "prop" paramater
-    '''
-
+    """Service that accepts a JSON document and adds or sets the "id" property to
+    the value of the property named by the "prop" parameter"""
     if not prop:
         # Remove this document
         response.code = 500
@@ -24,7 +21,7 @@ def selid(body, ctype, prop='handle', use_source='yes'):
 
     try:
         data = json.loads(body)
-    except:
+    except Exception:
         response.code = 500
         response.add_header('content-type', 'text/plain')
         return "Unable to parse body as JSON"
@@ -42,12 +39,9 @@ def selid(body, ctype, prop='handle', use_source='yes'):
             if v:
                 # Make an array of IDs (if needed) and iterate over it
                 for h in (v if isinstance(v, list) else [v]):
-                    """
-                    The only valid path to select a original ID for 
-                    Missouri is <mods:identifier type='local'>
-                    
-                    If this does not exist, no DPLA ID can be minted.
-                    """
+                    """ The only valid path to select a original ID for 
+                    Missouri is <mods:identifier type='local'>. If this does 
+                    not exist then no DPLA ID can be minted."""
                     if not record_id:
                         if getprop(h, "type", True) == "local":
                             record_id = textnode.textnode(h)

--- a/lib/akamod/select-id.py
+++ b/lib/akamod/select-id.py
@@ -4,13 +4,15 @@ from amara.lib.iri import is_absolute
 from akara.services import simple_service
 from akara.util import copy_headers_to_dict
 from akara import request, response
+from dplaingestion import textnode
 from dplaingestion.selector import getprop, exists
 from dplaingestion.utilities import couch_rec_id_builder, clean_id
-
+from akara import logger
 
 @simple_service('POST', 'http://purl.org/la/dp/select-id', 'select-id',
                 'application/json')
-def selid(body, ctype, prop='handle', use_source='yes'):
+def selid(body, ctype, prop='handle', attr=None,
+          attrValue=None, use_source='yes'):
     '''
     Service that accepts a JSON document and adds or sets the "id" property to
     the value of the property named by the "prop" paramater
@@ -33,15 +35,37 @@ def selid(body, ctype, prop='handle', use_source='yes'):
     source_name = request_headers.get('Source')
 
     record_id = None
+
     if exists(data, prop):
         v = getprop(data, prop)
         if isinstance(v, basestring):
             record_id = v
         else:
             if v:
+                # Make an array of IDs (if needed) and iterate over it
                 for h in (v if isinstance(v, list) else [v]):
-                    if is_absolute(h):
+                    # If attributes are provided to help select the
+                    # appropriate provider ID value then take the first match
+                    if not record_id and isinstance(h, dict) and attr and \
+                            attrValue:
+                        if h[attr].lower() == attrValue:
+                            record_id = textnode.textnode(h)
+                    # If no attributes are given then select the first
+                    # absolute URI
+                    elif not record_id and is_absolute(h):
                         record_id = h
+                # If no absolute URI was found then take the first value in the
+                # array of original record IDs
+
+                # TODO: This is a gap in the logic which might lead to IDs
+                # TODO: minted with the wrong base ID.
+                #
+                # For example:
+                # If Missouri gives us a record without
+                #   <mods:identifiers type="local">
+                # but with some <mods:identifiers>  select-id will just
+                # use the first value in that property.
+                # TODO: Is that what we want?
                 if not record_id:
                     record_id = v[0]
 

--- a/profiles/missouri.pjs
+++ b/profiles/missouri.pjs
@@ -13,7 +13,7 @@
         "/validate_mapv3"
     ],
     "enrichments_item": [
-        "/select-id?prop=metadata/mods/identifier&attr=type&attrValue=local",
+        "/select-id-missouri?prop=metadata/mods/identifier",
         "/dpla_mapper?mapper_type=missouri",
         "/strip_html",
         "/set_context",

--- a/profiles/missouri.pjs
+++ b/profiles/missouri.pjs
@@ -13,7 +13,7 @@
         "/validate_mapv3"
     ],
     "enrichments_item": [
-        "/select-id?prop=id",
+        "/select-id?prop=metadata/mods/identifier&attr=type&attrValue=local",
         "/dpla_mapper?mapper_type=missouri",
         "/strip_html",
         "/set_context",


### PR DESCRIPTION
Add support for selecting original record IDs based on attributes. For example, allows for selecting ids where attribute 'type' equals 'local'.

This was implemented after negotiating with Missouri about preserving their old IDs.