### PR TITLE
Post-enrichment count validation

### DIFF
--- a/scripts/check_fetch_and_enrich_counts.py
+++ b/scripts/check_fetch_and_enrich_counts.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+"""
+Script to check the added, changed, and removed counts of an ingestion
+document and email an alert if any threshold has been exceeded
+
+Usage:
+    $ python check_ingestion_counts.py ingestion_document_id
+"""
+import sys
+import argparse
+import traceback
+import smtplib
+import ConfigParser
+from dplaingestion.couch import Couch
+from email.mime.text import MIMEText
+
+
+def define_arguments():
+    """Defines command line arguments for the current script"""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("ingestion_document_id", help="The ID of the "
+                                                      "ingestion document")
+
+    return parser
+
+
+def alerts(i_doc):
+    """Return a string for the alerts part of the email
+
+    i_doc: the dict-like object from Couch.dashboard_db for the ingestion doc.
+    """
+    alerts = []
+
+    alerts.append("Alerts for ingestion document ID: %s" % i_doc["_id"])
+    count_type = ('fetch_process', 'enrich_process')
+    for ct in count_type:
+        count = int(i_doc[ct]["total_items"])
+        alerts.append("\t%s %d items" % (ct.lower().split("_")[0]+"ed", count))
+
+    return "\n".join(alerts)
+
+
+def main(argv):
+    parser = define_arguments()
+    args = parser.parse_args(argv[1:])
+
+    couch = Couch()
+    i_doc = couch.dashboard_db[args.ingestion_document_id]
+    if i_doc['enrich_process']['status'] != 'complete':
+        print >> sys.stderr, 'Error: enrich process did not complete'
+        return 1
+
+    error_msg = None
+    try:
+        config = ConfigParser.ConfigParser()                                    
+        config.readfp(open('akara.ini'))
+        to = [s.strip() for s in config.get('Alert', 'To').split(',')]
+        frm = config.get('Alert', 'From')
+        body = "%s" % (alerts(i_doc))
+        msg = MIMEText(body)
+        msg['Subject'] = "%s fetched and enriched %s" % \
+                         (i_doc['provider'], i_doc['ingestionSequence'])
+        msg['To'] = ', '.join(to)
+        msg['From'] = frm
+        s = smtplib.SMTP("localhost")
+        s.sendmail(frm, to, msg.as_string())
+        s.quit()
+    except Exception, e:
+        error_msg = e
+        tb = traceback.format_exc(5)
+        print >> sys.stderr, "Error sending alert email: %s\n%s" % (error_msg,
+                                                                    tb)
+
+    return 0
+
+if __name__ == '__main__':
+    rv = main(sys.argv)
+    sys.exit(rv)

--- a/scripts/ingest_fetch_and_enrich_provider.py
+++ b/scripts/ingest_fetch_and_enrich_provider.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+"""
+Script to ingest provider data
+
+Usage:
+    $ python ingest_fetch_and_enrich_provider.py profile_path
+"""
+import sys
+import argparse
+import create_ingestion_document
+import fetch_records
+import enrich_records
+import check_fetch_and_enrich_counts
+
+
+def define_arguments():
+    """Defines command line arguments for the current script"""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("profile_path",
+                        help="The path to the profile(s) to be processed",
+                        nargs="+")
+    return parser
+
+
+def main(argv):
+    parser = define_arguments()
+    args = parser.parse_args(argv[1:])
+
+    for profile_path in args.profile_path:
+        print "Creating ingestion document for profile %s" % profile_path
+        ingestion_doc_id = create_ingestion_document.main([None, profile_path])
+        if ingestion_doc_id is None:
+            print "Error creating ingestion document"
+            continue
+
+        resp = fetch_records.main([None, ingestion_doc_id])
+        if not resp == 0:
+            print "Error fetching records"
+            continue
+
+        resp = enrich_records.main([None, ingestion_doc_id])
+        if not resp == 0:
+            print "Error enriching records"
+            continue
+
+        resp = check_fetch_and_enrich_counts.main([None, ingestion_doc_id])
+        if not resp == 0:
+            print "Error checking counts"
+            continue
+
+        print "Fetch and enrich complete!!"
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/scripts/ingest_save_provider.py
+++ b/scripts/ingest_save_provider.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+"""
+Script to ingest provider data
+
+Usage:
+    $ python ingest_provider.py profile_path
+"""
+import sys
+import argparse
+import save_records
+import remove_deleted_records
+import check_ingestion_counts
+import dashboard_cleanup
+
+
+def define_arguments():
+    """Defines command line arguments for the current script"""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("ingestion_doc_id",
+                        help="The doc ID to process",
+                        nargs="+")
+    return parser
+
+
+def main(argv):
+    parser = define_arguments()
+    args = parser.parse_args(argv[1:])
+
+    for ingestion_doc_id in args.ingestion_doc_id:
+        resp = save_records.main([None, ingestion_doc_id])
+        if not resp == 0:
+            print "Error saving records"
+            continue
+
+        resp = remove_deleted_records.main([None, ingestion_doc_id])
+        if not resp == 0:
+            print "Error deleting records"
+            continue
+
+        resp = check_ingestion_counts.main([None, ingestion_doc_id])
+        if not resp == 0:
+            print "Error checking counts"
+            continue
+
+        resp = dashboard_cleanup.main([None, ingestion_doc_id])
+        if not resp == 0:
+            print "Error cleaning up dashboard"
+            continue
+
+        print "Ingestion complete!"
+
+if __name__ == '__main__':
+    main(sys.argv)


### PR DESCRIPTION
Split up the ingest process into separate fetch/enrich steps and a save/delete/cleanup step with an email summary report after each step.

Running an ingest when you want to validate the counts after havest and mapping/enrichment will look like this:
`python scripts/ingest_fetch_and_enrich_provider.py profiles/<provider.pjs>`
`python scripts/ingest_save_provider.py <ingest_doc_id>`

The ingest_doc_id will be included in the first summary email so users will not need to look it up in Couch.