### PR TITLE
Fix UTF-8 encoding problem with fetchers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 
 # command to install dependencies
 install:
-  - pip install -r requirements.txt --use-mirrors
+  - pip install -r requirements.txt
   - python setup.py install
 
 # command to run tests

--- a/lib/fetchers/fetcher.py
+++ b/lib/fetchers/fetcher.py
@@ -15,7 +15,7 @@ from amara.lib.iri import is_absolute
 from dplaingestion.selector import exists
 from dplaingestion.selector import setprop
 from dplaingestion.selector import getprop as get_prop
-from dplaingestion.utilities import iterify, couch_id_builder
+from dplaingestion.utilities import iterify, couch_id_builder, utf8str
 import requests
 from requests import RequestException
 import re
@@ -25,7 +25,7 @@ def getprop(obj, path):
     return get_prop(obj, path, keyErrorAsNone=True)
 
 
-XML_PARSE = lambda doc: xmltodict.parse(doc,
+XML_PARSE = lambda doc: xmltodict.parse(utf8str(doc),
                                         xml_attribs=True,
                                         attr_prefix='',
                                         force_cdata=False,

--- a/lib/fetchers/fetcher.py
+++ b/lib/fetchers/fetcher.py
@@ -24,7 +24,10 @@ import re
 def getprop(obj, path):
     return get_prop(obj, path, keyErrorAsNone=True)
 
-
+# XML_PARSE: wrapper around xmltodict.parse, which needs a _string_ (str or
+# unicode), not a filehandle, because of the assurance that we want to provide
+# with utf8str() that it is Unicode.  (xmltodict.parse takes either a string or
+# filehandle.)
 XML_PARSE = lambda doc: xmltodict.parse(utf8str(doc),
                                         xml_attribs=True,
                                         attr_prefix='',

--- a/lib/fetchers/file_fetcher.py
+++ b/lib/fetchers/file_fetcher.py
@@ -13,9 +13,9 @@ class FileFetcher(Fetcher):
     def extract_xml_content(self, filepath):
         error = None
         content = None
-        file = open(filepath, "r")
+        xmlfile = open(filepath, "r")
         try:
-            content = XML_PARSE(file)
+            content = XML_PARSE(xmlfile.read())
         except:
             error = "Error parsing content from file %s" % filepath
 

--- a/lib/utilities.py
+++ b/lib/utilities.py
@@ -162,3 +162,12 @@ def url_join(*args):
 
     """
     return "/".join(map(lambda x: str(x).rstrip("/"), args))
+
+
+def utf8str(s):
+    """Return the given String or Unicode String as a Unicode string"""
+    try:
+        return s.encode('utf-8')
+    except UnicodeEncodeError:
+        # It was already a Unicode string.
+        return s

--- a/lib/utilities.py
+++ b/lib/utilities.py
@@ -167,7 +167,7 @@ def url_join(*args):
 def utf8str(s):
     """Return the given String or Unicode String as a Unicode string"""
     try:
-        return s.encode('utf-8')
+        return s.encode('utf-8')  # For an ASCII string
     except UnicodeEncodeError:
-        # It was already a Unicode string.
+        # It was not an ASCII string.
         return s


### PR DESCRIPTION
Explicitly encode XML strings in the XML_PARSE lambda that will get passed to `xmltodict.parse()` and then to `xml.parsers.expat.Parse()`. Otherwise, they can be treated in an ASCII String (`str`) context and an exception is thrown when trying to convert characters whose ordinals are higher than 128.

See https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1559

I have tested this by:
1. Trying a fetch with the original code to verify the failure
2. Trying a fetch with the fixed code and letting it run past 4500 records fetched. (It was failing in the 4000 block.)
