### PR TITLE
Remove --use-mirrors from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 
 # command to install dependencies
 install:
-  - pip install -r requirements.txt --use-mirrors
+  - pip install -r requirements.txt
   - python setup.py install
 
 # command to run tests


### PR DESCRIPTION
`pip --use-mirrors` is no longer supported.