### PR TITLE
Fix/nypl harvests

### DIFF
--- a/lib/fetchers/nypl_fetcher.py
+++ b/lib/fetchers/nypl_fetcher.py
@@ -4,6 +4,8 @@ from dplaingestion.fetchers.fetcher import getprop
 from dplaingestion.fetchers.absolute_url_fetcher import AbsoluteURLFetcher
 from dplaingestion.fetchers.fetcher import XML_PARSE
 
+import threading
+
 class NYPLFetcher(AbsoluteURLFetcher):
     def __init__(self, profile, uri_base, config_file):
         super(NYPLFetcher, self).__init__(profile, uri_base, config_file)


### PR DESCRIPTION
These are changes I made to get NYPL to harvest. 

One of them implements request retrying as a per-provider option. That got me past a failing response issue with the NYPL API, and may be generally useful.