### PR TITLE
Fixup queries for both Minnesota and South Dakota

### DIFF
--- a/profiles/minnesota.pjs
+++ b/profiles/minnesota.pjs
@@ -3,8 +3,9 @@
     "type": "mdl",
     "endpoint_url": "http://hub-client.lib.umn.edu/api/v1/records",
     "endpoint_url_params": {
-        "q": "tags_ssim:dpla",
-        "start": 0
+        "q": "tags_ssim:dpla AND -import_job_name_ssi:\"Digital Library of South Dakota\"",
+        "start": 0,
+        "per_page": 100
     },
     "fetcher_threads": 4,
     "contributor": {

--- a/profiles/sd.pjs
+++ b/profiles/sd.pjs
@@ -3,8 +3,9 @@
     "type": "mdl",
     "endpoint_url": "http://hub-client.lib.umn.edu/api/v1/records",
     "endpoint_url_params": {
-        "q": "import_job_id_isi:71",
-        "start": 0
+        "q": "import_job_name_ssi:\"Digital Library of South Dakota\"",
+        "start": 0,
+        "per_page": 100
     },
     "fetcher_threads": 4,
     "contributor": {


### PR DESCRIPTION
* Exclude South Dakota from MDL
* Make SD query more accurate