### PR TITLE
Fix/usc type shred

### DIFF
--- a/lib/itemtype.py
+++ b/lib/itemtype.py
@@ -23,13 +23,23 @@ def type_for_strings_and_mappings(string_map_combos):
     Given pairs of (list of strings, list of mapping tuples), try to find a
     suitable item type.
     """
+
+    typed = []
     for strings, mappings in string_map_combos:
         # Try each of our strings to see if a keyword falls within it
         for s in strings:
             t = _type_for_keyword(s, mappings)
-            if t:
-                return t
-    raise NoTypeError
+            if isinstance(t, list):
+                for i in t:
+                    typed.append(i)
+            else:
+                typed.append(t)
+
+    if typed:
+        # Gets distinct values
+        return list(set(typed))
+    else:
+        raise NoTypeError
 
 def rejects(string_map_combos):
     """rejects([(list, list_of_tuples), ...])

--- a/lib/itemtype.py
+++ b/lib/itemtype.py
@@ -35,7 +35,7 @@ def type_for_strings_and_mappings(string_map_combos):
             else:
                 typed.append(t)
 
-    if typed:
+    if len(typed) > 0:
         # Gets distinct values
         return list(set(typed))
     else:

--- a/profiles/usc.pjs
+++ b/profiles/usc.pjs
@@ -61,6 +61,7 @@
         "/shred?prop=sourceResource%2Flanguage%2CsourceResource%2Fpublisher%2CsourceResource%2Frelation", 
         "/shred?prop=sourceResource%2Fsubject%2CsourceResource%2Ftype%2CsourceResource%2Fformat", 
         "/shred?prop=sourceResource%2Fsubject&delim=%3Cbr%3E",
+        "/shred?prop=sourceResource%2Ftype",
         "/cleanup_value",
         "/move_date_values?prop=sourceResource%2Fspatial&to_prop=sourceResource%2Fdate",
         "/capitalize_value",

--- a/test/test_enrich_type.py
+++ b/test/test_enrich_type.py
@@ -53,7 +53,7 @@ def test_type_for_phys_keyword():
     EXPECTED = {
         "id": "123",
         "sourceResource": {
-            "type": "image",
+            "type": ["image"],
             "format": "Holiday Card"
         }
     }
@@ -71,7 +71,7 @@ def test_type_for_type_keyword():
     EXPECTED = {
         "id": "123",
         "sourceResource": {
-            "type": "image"
+            "type": ["image"]
         }
     }
     resp, content = _get_server_response(json.dumps(INPUT))
@@ -88,7 +88,7 @@ def test_type_for_type_keyword2():
     EXPECTED = {
         "id": "123",
         "sourceResource": {
-            "type": ["image", "text"]
+            u"type": [u"text", u"image"]
         }
     }
     resp, content = _get_server_response(json.dumps(INPUT))
@@ -103,14 +103,14 @@ def test_type_set_format():
     """
     url = server() + "enrich-type?send_rejects_to_format=true"
     INPUT = {
-        "sourceResource": {
-            "type": "digital photograph"
+        u"sourceResource": {
+            u"type": u"digital photograph"
         }
     }
     EXPECTED = {
-        "sourceResource": {
-            "type": "image",
-            "format": ["digital photograph"]
+        u"sourceResource": {
+            u"type": [u"image"],
+            u"format": [u"digital photograph"]
         }
     }
     resp, content = H.request(url, "POST", body=json.dumps(INPUT))
@@ -123,7 +123,7 @@ def test_type_set_format():
     }
     EXPECTED = {
         "sourceResource": {
-            "type": "text"
+            "type": ["text"]
         }
     }
     resp, content = H.request(url, "POST", body=json.dumps(INPUT))


### PR DESCRIPTION
Split USC's type field on `;` 
Modify `type_for_strings_and_mappings` to return all unique terms where they are matched against our lookups. Previously only the first match would be returned. 