### PR TITLE
Fix save_jsonl.py: add newline for each record

### DIFF
--- a/scripts/save_jsonl.py
+++ b/scripts/save_jsonl.py
@@ -65,7 +65,7 @@ def write_jsonl(enrich_dir, output_filename):
                                  '_id': doc['_id'],
                                 '_source': doc
                                 },
-                                ensure_ascii=False)))
+                                ensure_ascii=False) + "\n"))
                         total_items += 1
 
             print >> sys.stderr, "Read file %s" % filename


### PR DESCRIPTION
We need each object in the JSONL file to have a newline.

This issue prevents our elasticsearch indexer from being able to read the file.
