### PR TITLE
MWDL mapping fixes and UTF-8 encoding error

### DIFF
--- a/lib/fetchers/fetcher.py
+++ b/lib/fetchers/fetcher.py
@@ -26,11 +26,21 @@ def getprop(obj, path):
     return get_prop(obj, path, keyErrorAsNone=True)
 
 
-XML_PARSE = lambda doc: xmltodict.parse(doc,
-                                        xml_attribs=True,
-                                        attr_prefix='',
-                                        force_cdata=False,
-                                        ignore_whitespace_cdata=True)
++XML_PARSE = lambda doc: xmltodict.parse(xmltodict_str(doc),
+                                         xml_attribs=True,
+                                         attr_prefix='',
+                                         force_cdata=False,
+                                         ignore_whitespace_cdata=True)
+
+def xmltodict_str(s):
+    """Temporary kludge to get Getty to work"""
+    try:
+        # encode() converts a `unicode' string to a byte string (`str').
+        # `decode()` converts a byte string (`str') to Unicode.
+        # `encode()` converts a `unicode' string to a `str' byte string.
+        return s.encode('utf-8')
+    except UnicodeEncodeError:
+        return s
 
 
 class Fetcher(object):

--- a/lib/fetchers/fetcher.py
+++ b/lib/fetchers/fetcher.py
@@ -26,11 +26,12 @@ def getprop(obj, path):
     return get_prop(obj, path, keyErrorAsNone=True)
 
 
-+XML_PARSE = lambda doc: xmltodict.parse(xmltodict_str(doc),
-                                         xml_attribs=True,
-                                         attr_prefix='',
-                                         force_cdata=False,
-                                         ignore_whitespace_cdata=True)
+XML_PARSE = lambda doc: xmltodict.parse(xmltodict_str(doc),
+                                        xml_attribs=True,
+                                        attr_prefix='',
+                                        force_cdata=False,
+                                        ignore_whitespace_cdata=True)
+
 
 def xmltodict_str(s):
     """Temporary kludge to get Getty to work"""

--- a/lib/mappers/mwdl_mapper.py
+++ b/lib/mappers/mwdl_mapper.py
@@ -84,13 +84,12 @@ class MWDLMapper(PrimoMapper):
             self.update_source_resource({"isPartOf": "; ".join(ipo)})
  
     def map_title(self):
-        props = (self.root_key + "display/title")
+        prop = self.root_key + "display/title"
 
         title = []
-        for prop in props:
-            values = getprop(self.provider_data, prop, True)
-            if values:
-                [title.append(v) for v in iterify(values) if v not in title]
+        values = getprop(self.provider_data, prop, True)
+        if values:
+            [title.append(v) for v in iterify(values) if v not in title]
 
         if title:
             self.update_source_resource({"title": "; ".join(title)})

--- a/lib/mappers/mwdl_mapper.py
+++ b/lib/mappers/mwdl_mapper.py
@@ -2,6 +2,7 @@ from dplaingestion.utilities import iterify
 from dplaingestion.selector import exists, getprop
 from dplaingestion.mappers.primo_mapper import PrimoMapper
 
+
 class MWDLMapper(PrimoMapper):
     def __init__(self, provider_data):
         super(MWDLMapper, self).__init__(provider_data)
@@ -11,8 +12,20 @@ class MWDLMapper(PrimoMapper):
                                "dlDisplay.do?vid=MWDL&afterPDS=true&docId="
 
     def map_date(self):
-        self._map_source_resource_prop("date",
-                                       self.root_key + "search/creationdate")
+        displayDateProp = self.root_key + "display/creationdate"
+        searchDateProp = self.root_key + "search/creationdate"
+
+        dates = []
+        searchValues = getprop(self.provider_data, searchDateProp, True)
+        displayValues = getprop(self.provider_data, displayDateProp, True)
+
+        if searchValues:
+            [dates.append(v) for v in iterify(searchValues) if v not in dates]
+        elif displayValues:
+            [dates.append(v) for v in iterify(displayValues) if v not in dates]
+
+        if dates:
+            self.update_source_resource({"date": dates})
 
     def map_description(self):
         self._map_source_resource_prop("description",
@@ -71,8 +84,7 @@ class MWDLMapper(PrimoMapper):
             self.update_source_resource({"isPartOf": "; ".join(ipo)})
  
     def map_title(self):
-        props = (self.root_key + "display/title",
-                 self.root_key + "display/lds10")
+        props = (self.root_key + "display/title")
 
         title = []
         for prop in props:

--- a/profiles/mwdl.pjs
+++ b/profiles/mwdl.pjs
@@ -2,6 +2,7 @@
     "name": "mwdl",
     "type": "mwdl",
     "endpoint_url": "http://utah-primoprod.hosted.exlibrisgroup.com/PrimoWebServices/xservice/search/brief",
+
     "endpoint_url_params": {
         "indx": 1,
         "bulkSize": 100,
@@ -10,18 +11,7 @@
         "query": "facet_tlevel,exact,online_resources",
         "query_exc": [
             "facet_rtype,exact,collections",
-            "lsr04,exact,2082",
-            "lsr04,exact,1053",
-            "lsr04,exact,1067",
-            "lsr04,exact,1099",
-            "lsr04,exact,1100",
-            "lsr04,exact,1101",
-            "lsr04,exact,1249",
-            "lsr04,exact,1250",
-            "lsr04,exact,1276",
-            "lsr04,exact,1283",
-            "lsr04,exact,1617",
-            "lsr04,exact,2019"
+            "facet_scope,exact,dd"
         ]
     },
     "sets": "NotSupported",


### PR DESCRIPTION
Fixes mapping issues in MWDL 

**Primo encoding fix**
Both Getty and MWDL (the only Primo providers) were not able to be harvested because of an encoding issue in the feeds.  This adds a function to explictiy encode the string as a utf-8 byte string.  `XML_PARSE` is a core method for all fetchers. 