### PR TITLE
Fix handling of bogus dates

### DIFF
--- a/lib/akamod/enrich_date.py
+++ b/lib/akamod/enrich_date.py
@@ -39,7 +39,12 @@ def out_of_range(d):
 
 # EDTF: http://www.loc.gov/standards/datetime/pre-submission.html
 # (like ISO-8601 but doesn't require timezone)
-edtf_date_and_time = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
+edtf_date_and_time = re.compile(
+    r"\d{4}-\d{2}-\d{2}"
+    r"T(?:[0-1][0-9]|2[0-3])"
+    r":(?:[0-5][0-9])"
+    r":(?:[0-5][0-9])"
+)
 
 def robust_date_parser(d):
     """
@@ -88,17 +93,17 @@ def robust_date_parser(d):
     return isodate
 
 # ie 1970/1971
-year_range = re.compile("(?P<year1>^\d{4})[-/](?P<year2>\d{4})$")
+year_range = re.compile(r"^(?P<year1>^\d{4})[-/](?P<year2>\d{4})$")
 # ie 1970-08-01/02
-day_range = re.compile("(?P<year>^\d{4})[-/](?P<month>\d{1,2})[-/](?P<day_begin>\d{1,2})[-/](?P<day_end>\d{1,2}$)")
+day_range = re.compile(r"^(?P<year>^\d{4})[-/](?P<month>\d{1,2})[-/](?P<day_begin>\d{1,2})[-/](?P<day_end>\d{1,2})$")
 # ie 1970-90
-circa_range = re.compile("(?P<century>\d{2})(?P<year_begin>\d{2})[-/](?P<year_end>\d{1,2})")
+circa_range = re.compile(r"^(?P<century>\d{2})(?P<year_begin>\d{2})[-/](?P<year_end>\d{1,2})$")
 # ie 9-1970
-month_year = re.compile("(?P<month>\d{1,2})[-/](?P<year>\d{4})")
+month_year = re.compile(r"^(?P<month>\d{1,2})[-/](?P<year>\d{4})$")
 # ie 195- 
-decade_date = re.compile("(?P<year>\d{3})-")
+decade_date = re.compile(r"^(?P<year>\d{3})-$")
 # ie 1920s
-decade_date_s = re.compile("(?P<year>\d{4})s")
+decade_date_s = re.compile(r"^(?P<year>\d{4})s$")
 # ie between 2000 and 2002
 between_date = re.compile("between\s*(?P<year1>\d{4})\s*and\s*(?P<year2>\d{4})")
 

--- a/test/test_enrich_date.py
+++ b/test/test_enrich_date.py
@@ -6,8 +6,8 @@ from dict_differ import DictDiffer, assert_same_jsons, pinfo
 import sys
 
 
-def test_enrich_dates_bogus_date():
-    """Correctly transform a date value that cannot be parsed"""
+def test_enrich_dates_bogus_date_1():
+    """Correctly transform a date value that cannot be parsed (1)"""
     INPUT = {
         "date" : "could be 1928ish?"
     }
@@ -28,6 +28,68 @@ def test_enrich_dates_bogus_date():
     result = json.loads(content)
     assert result['date'] == EXPECTED[u'date']
 
+def test_enrich_dates_bogus_date_2():
+    """Correctly transform a date value that cannot be parsed (2)"""
+    INPUT = {
+        "date": "1896-19#"
+    }
+    EXPECTED = {
+        u'date' : {
+            'begin' : None,
+            'end' : None,
+            'displayDate': '1896-19#'
+        }
+    }
+
+    url = server() + "enrich_earliest_date?prop=date"
+
+    resp,content = H.request(url,"POST",body=json.dumps(INPUT))
+
+    assert str(resp.status).startswith("2")
+
+    result = json.loads(content)
+    assert_same_jsons(result['date'], EXPECTED[u'date'])
+
+def test_enrich_bogus_date_3():
+    """Correctly transform a date value that cannot be parsed (3)"""
+    INPUT = {
+        # Uh, you mean 1969-03-26T00:00:00? We can't tell for sure.
+        "date": "1969-03-25T24:00:00"
+    }
+    EXPECTED = {
+        u'date': {
+            'begin': None,
+            'end': None,
+            'displayDate': '1969-03-25T24:00:00'
+        }
+    }
+    url = server() + "enrich_earliest_date?prop=date"
+    resp,content = H.request(url,"POST",body=json.dumps(INPUT))
+    result = json.loads(content)
+    print result
+    assert result['date'] == EXPECTED[u'date']
+
+def test_enrich_dates_bogus_date_4():
+    """Correctly transform a date value that cannot be parsed (4)"""
+    INPUT = {
+        "date": "1991-0u"
+    }
+    EXPECTED = {
+        u'date' : {
+            'begin' : None,
+            'end' : None,
+            'displayDate': '1991-0u'
+        }
+    }
+
+    url = server() + "enrich_earliest_date?prop=date"
+
+    resp,content = H.request(url,"POST",body=json.dumps(INPUT))
+
+    assert str(resp.status).startswith("2")
+
+    result = json.loads(content)
+    assert_same_jsons(result['date'], EXPECTED[u'date'])
 
 def test_enrich_date_single():
     """Correctly transform a single date value"""


### PR DESCRIPTION
Correctly assign a JSON object to sourceResource.date when encountering bad dates, instead of failing and allowing it to be assigned as a string of the original value.

This fixes the problems documented in:
- https://digitalpubliclibraryofamerica.atlassian.net/browse/IN-466
- https://digitalpubliclibraryofamerica.atlassian.net/browse/IN-467