### PR TITLE
Fix name-not-defined error, enrich-type

### DIFF
--- a/lib/akamod/enrich-type.py
+++ b/lib/akamod/enrich-type.py
@@ -3,7 +3,9 @@ from akara.services import simple_service
 from amara.thirdparty import json
 from dplaingestion.selector import delprop, getprop, setprop, exists
 import dplaingestion.itemtype as itemtype
+from dplaingestion.textnode import textnode, NoTextNodeError
 import re
+
 
 type_for_type_keyword = \
     module_config('enrich_type').get('type_for_ot_keyword')
@@ -52,19 +54,17 @@ def enrichtype(body, ctype,
                        id_for_msg)
         return body
     if sr_type:
-        for t in sr_type if (type(sr_type) == list) else [sr_type]:
-            if type(t) == dict:
-                t = t.get('#text', '')
-            if t is not None:
-                type_strings.append(t.lower())
+        for t in list(sr_type):
+            try:
+                type_strings.append(textnode(t).lower())
+            except NoTextNodeError:
+                pass
     if sr_format:
-        for f in sr_format if (type(sr_format) == list) else [sr_format]:
-            if f is not None:
-                if isinstance(f, list):
-                    st = f
-                else:
-                    st = [textnode(f)]
-                format_strings.append(st.lower())
+        for f in list(sr_format):
+            try:
+                format_strings.append(textnode(f).lower())
+            except NoTextNodeError:
+                pass
     try:
         data['sourceResource']['type'] = \
             itemtype.type_for_strings_and_mappings([

--- a/test/test_enrich_type.py
+++ b/test/test_enrich_type.py
@@ -143,5 +143,39 @@ def test_type_set_format():
     assert resp.status == 200
     assert_same_jsons(EXPECTED, json.loads(content))
 
+def test_type_from_textnode():
+    INPUT = {
+        "sourceResource": {
+            "type": [
+                "still image",
+                {"#text": "text", "usage": "primary"}
+            ],
+            "format": ["x"]
+        }
+    }
+    EXPECTED = {
+        "sourceResource": {
+            u"type": [u"text", u"image"],
+            u"format": [u"x"]
+        }
+    }
+    resp, content = _get_server_response(json.dumps(INPUT))
+    assert resp.status == 200
+    assert_same_jsons(EXPECTED, json.loads(content))
+
+def test_type_textnode_error_handling():
+    INPUT = {
+        "sourceResource": {
+            "type": {"buggy": "data"}
+        }
+    }
+    EXPECTED = {
+        "sourceResource": {}
+    }
+    resp, content = _get_server_response(json.dumps(INPUT))
+    assert resp.status == 200
+    assert_same_jsons(EXPECTED, json.loads(content))
+
+
 if __name__ == "__main__":
     raise SystemExit("Use nosetest")


### PR DESCRIPTION
Fix a name-not-defined error in enrich-type.py that passed through previously porous test coverage. Also clean up syntax of type enrichment.

Previously, a line in `enrich-type.py` [called `textnode()` without it having been imported](https://github.com/dpla/ingestion/blob/dc4be48aaec42e2801c03e9971ac0b3f6c3a850d/lib/akamod/enrich-type.py#L66).  The tests that I've added for `enrichtype()` used to reveal the following error, before I made the code change:
```
Jul 12 15:50:35 akara[11446]: [ERROR] Uncaught exception from 'enrich-type' ('http://purl.org/la/dp/enrich-type')
Traceback (most recent call last):
  File "/Users/mark/venv/ingestion/lib/python2.7/site-packages/akara/multiprocess_http.py", line 304, in _wsgi_application
    result = service.handler(environ, start_response_)
  File "/Users/mark/venv/ingestion/lib/python2.7/site-packages/akara/services.py", line 417, in wrapper
    result = func(*args, **kwargs)
  File "/Users/mark/venv/ingestion/lib/python2.7/site-packages/dplaingestion/akamod/enrich-type.py", line 66, in enrichtype
    st = [textnode(f)]
NameError: global name 'textnode' is not defined
```

The failure was causing the enrichment to not enrich `sourceResource.type` for affected records.

I've cleaned up the relevant part of the function to make better use of `textnode()`, and have added some tests.
